### PR TITLE
Auth refactor for iTwin 3.2 and auth support for Android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: iTwin/mobile-native-android
-        ref: '3.1.10'
+        ref: '3.2.8'
         token: ${{ secrets.GH_PAT }}
         path: mobile-native-android
 
@@ -47,7 +47,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         cd mobile-native-android
-        gh release download 3.1.10 -p '*.aar'
+        gh release download 3.2.8 -p '*.aar'
         chmod +x gradlew
         ./gradlew publishToMavenLocal
         cd ..

--- a/.idea/dictionaries/itwin_mobile.xml
+++ b/.idea/dictionaries/itwin_mobile.xml
@@ -10,7 +10,9 @@
       <w>itwin</w>
       <w>itwinjs</w>
       <w>itwinstarter</w>
+      <w>noninfringement</w>
       <w>realitydata</w>
+      <w>signin</w>
       <w>webview</w>
     </words>
   </dictionary>

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ This is pre-release software and provided as-is.
 This repository contains the Kotlin code used to build [iTwin.js](http://www.itwinjs.org) applications on Android devices.
 
 ## Note
-This package is designed to be used with the [@itwin/mobile-sdk-core](https://github.com/iTwin/mobile-sdk-core) and [@itwin/mobile-ui-react](https://github.com/iTwin/mobile-ui-react) packages. Those two packages are intended to be installed via npm, and their version number must match the version number of this package. Furthermore, they use __iTwin.js 3.2.0-dev.76__, and your app must use that same version of iTwin.js.
+This package is designed to be used with the [@itwin/mobile-sdk-core](https://github.com/iTwin/mobile-sdk-core) and [@itwin/mobile-ui-react](https://github.com/iTwin/mobile-ui-react) packages. Those two packages are intended to be installed via npm, and their version number must match the version number of this package. Furthermore, they use __iTwin.js 3.2.0__, and your app must use that same version of iTwin.js.

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ This is pre-release software and provided as-is.
 This repository contains the Kotlin code used to build [iTwin.js](http://www.itwinjs.org) applications on Android devices.
 
 ## Note
-This package is designed to be used with the [@itwin/mobile-sdk-core](https://github.com/iTwin/mobile-sdk-core) and [@itwin/mobile-ui-react](https://github.com/iTwin/mobile-ui-react) packages. Those two packages are intended to be installed via npm, and their version number must match the version number of this package. Furthermore, they use __iTwin.js 3.1.3__, and your app must use that same version of iTwin.js.
+This package is designed to be used with the [@itwin/mobile-sdk-core](https://github.com/iTwin/mobile-sdk-core) and [@itwin/mobile-ui-react](https://github.com/iTwin/mobile-ui-react) packages. Those two packages are intended to be installed via npm, and their version number must match the version number of this package. Furthermore, they use __iTwin.js 3.2.0-dev.76__, and your app must use that same version of iTwin.js.

--- a/mobile-sdk/build.gradle
+++ b/mobile-sdk/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.5.0"
-    api 'com.github.itwin:mobile-native-android:3.2.7'
+    api 'com.github.itwin:mobile-native-android:3.2.8'
 
     // testImplementation 'junit:junit:4.+'
     // androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/mobile-sdk/build.gradle
+++ b/mobile-sdk/build.gradle
@@ -50,7 +50,8 @@ dependencies {
     implementation 'com.google.android.gms:play-services-location:19.0.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.5.0"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.5.0'
+    implementation 'net.openid:appauth:0.11.1'
     api 'com.github.itwin:mobile-native-android:3.2.8'
 
     // testImplementation 'junit:junit:4.+'

--- a/mobile-sdk/build.gradle
+++ b/mobile-sdk/build.gradle
@@ -41,6 +41,7 @@ android {
 dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation "androidx.fragment:fragment-ktx:1.4.1"
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.code.gson:gson:2.9.0'

--- a/mobile-sdk/build.gradle
+++ b/mobile-sdk/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.5.0"
-    api 'com.github.itwin:mobile-native-android:3.1.10'
+    api 'com.github.itwin:mobile-native-android:3.2.7'
 
     // testImplementation 'junit:junit:4.+'
     // androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMActionSheet.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMActionSheet.kt
@@ -82,19 +82,7 @@ class ITMActionSheet(nativeUI: ITMNativeUI): ITMNativeUIComponent(nativeUI) {
             return suspendCoroutine { continuation ->
                 this.continuation = continuation
                 var resumed = false
-                var popupGravity = Gravity.NO_GRAVITY
-                params.getOptionalString("gravity")?.let { gravity ->
-                    when (gravity) {
-                        "top" -> popupGravity = Gravity.TOP
-                        "bottom" -> popupGravity = Gravity.BOTTOM
-                        "left" -> popupGravity = Gravity.LEFT
-                        "right" -> popupGravity = Gravity.RIGHT
-                        "topLeft" -> popupGravity = Gravity.TOP or Gravity.LEFT
-                        "topRight" -> popupGravity = Gravity.TOP or Gravity.RIGHT
-                        "bottomLeft" -> popupGravity = Gravity.BOTTOM or Gravity.LEFT
-                        "bottomRight" -> popupGravity = Gravity.BOTTOM or Gravity.RIGHT
-                    }
-                }
+                val popupGravity = params.getOptionalString("gravity")?.toGravity() ?: Gravity.NO_GRAVITY
                 with(PopupMenu(context, anchor, popupGravity)) {
                     setOnMenuItemClickListener { item ->
                         resumed = true
@@ -153,5 +141,19 @@ class ITMActionSheet(nativeUI: ITMNativeUI): ITMNativeUIComponent(nativeUI) {
         continuation?.resume(Json.value(cancelAction?.name))
         continuation = null
         cancelAction = null
+    }
+}
+
+private fun String.toGravity(): Int {
+    return when (this) {
+        "top" -> Gravity.TOP
+        "bottom" -> Gravity.BOTTOM
+        "left" -> Gravity.LEFT
+        "right" -> Gravity.RIGHT
+        "topLeft" -> Gravity.TOP or Gravity.LEFT
+        "topRight" -> Gravity.TOP or Gravity.RIGHT
+        "bottomLeft" -> Gravity.BOTTOM or Gravity.LEFT
+        "bottomRight" -> Gravity.BOTTOM or Gravity.RIGHT
+        else -> Gravity.NO_GRAVITY
     }
 }

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAlert.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAlert.kt
@@ -42,6 +42,12 @@ class ITMAlert(nativeUI: ITMNativeUI): ITMNativeUIComponent(nativeUI)  {
         Destructive
     }
 
+    /**
+     * Class representing an action that the user can select.
+     *
+     * @param value [JsonValue] containing required `name` and `title` values, as well as optionally a
+     * `style` value.
+     */
     class Action(value: JsonValue) {
         val name: String
         val title: String

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
@@ -658,6 +658,9 @@ abstract class ITMApplication(
      * @return And instance of [AuthorizationClient].
      */
     open fun getAuthorizationClient(): AuthorizationClient? {
+        configData?.let { configData ->
+            return ITMAuthorizationClient(this, configData)
+        }
         return null
     }
 

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
@@ -136,7 +136,7 @@ abstract class ITMApplication(
      * The fragment used to present a sign in UI to the user.
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    protected var authorizationFragment: ITMOIDCAuthorizationFragment? = null
+    protected var authorizationFragment: ITMAuthorizationFragment? = null
 
     /**
      * The AuthorizationClient used for authentication.
@@ -369,7 +369,7 @@ abstract class ITMApplication(
                         geolocationFragment = frag
                     }
                 }
-                (authorizationClient as? ITMOIDCAuthorizationClient)?.let { authorizationClient ->
+                (authorizationClient as? ITMAuthorizationClient)?.let { authorizationClient ->
                     fragmentActivity.supportFragmentManager.commit {
                         setReorderingAllowed(true)
                         val frag = createAuthorizationFragment(authorizationClient)
@@ -697,9 +697,10 @@ abstract class ITMApplication(
      *
      * Override this function in a subclass in order to add custom behavior.
      *
-     * If your application handles authorization on its own, create a subclass of [AuthorizationClient].
+     * If your application handles authorization on its own, create a subclass of [AuthorizationClient] or
+     * [ITMAuthorizationClient].
      *
-     * @return And instance of [AuthorizationClient], or null if you don't want any authentication in your app.
+     * @return An instance of [AuthorizationClient], or null if you don't want any authentication in your app.
      */
     open fun createAuthorizationClient(): AuthorizationClient? {
         configData?.let { configData ->
@@ -715,23 +716,30 @@ abstract class ITMApplication(
      *
      * @param geolocationManager The [ITMGeolocationManager] to use with the fragment.
      *
-     * @return And instance of [ITMGeolocationFragment] attached to [geolocationManager].
+     * @return An instance of [ITMGeolocationFragment] attached to [geolocationManager].
      */
     open fun createGeolocationFragment(geolocationManager: ITMGeolocationManager): ITMGeolocationFragment {
         return ITMGeolocationFragment(geolocationManager)
     }
 
     /**
-     * Creates the [ITMOIDCAuthorizationFragment] to be used for this iTwin Mobile web app.
+     * Creates the [ITMAuthorizationFragment] to be used for this iTwin Mobile web app.
      *
      * Override this function in a subclass in order to add custom behavior.
      *
-     * @param client The [ITMOIDCAuthorizationClient] to use with the fragment.
+     * __Note:__ If your [AuthorizationClient] is not a subclass of [ITMAuthorizationClient], this function
+     * will never be called. If you need a fragment to go with it, you are reponsible for setting it up yourself.
+     * If your [AuthorizationClient] _is_ a subclass of [ITMAuthorizationClient], then the [client] param
+     * passed here will be an instance of that class.
      *
-     * @return And instance of [ITMOIDCAuthorizationFragment] attached to [client].
+     * @param client The [ITMAuthorizationClient] to use with the fragment.
+     *
+     * @return An instance of [ITMOIDCAuthorizationFragment] attached to [client]. If this default implementation
+     * is called, [authorizationClient] __must__ be an [ITMOIDCAuthorizationClient].
      */
-    open fun createAuthorizationFragment(client: ITMOIDCAuthorizationClient): ITMOIDCAuthorizationFragment {
-        return ITMOIDCAuthorizationFragment(client)
+    open fun createAuthorizationFragment(client: ITMAuthorizationClient): ITMAuthorizationFragment {
+        val oidcClient = client as? ITMOIDCAuthorizationClient ?: throw Error("client is not ITMOIDCAuthorizationClient.")
+        return ITMOIDCAuthorizationFragment(oidcClient)
     }
 //    private fun loadFrontend() {
 //        val host = this.host ?: return

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
@@ -133,6 +133,12 @@ abstract class ITMApplication(
     protected var geolocationFragment: ITMGeolocationFragment? = null
 
     /**
+     * The fragment used to present a sign in UI to the user.
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    protected var authorizationFragment: ITMAuthorizationFragment? = null
+
+    /**
      * The AuthorizationClient used for authentication.
      */
     @Suppress("MemberVisibilityCanBePrivate")
@@ -363,9 +369,13 @@ abstract class ITMApplication(
                         geolocationFragment = frag
                     }
                 }
-                (authorizationClient as? ITMAuthorizationClient)?.let { /*authorizationClient ->*/
-                    // Set up ITMAuthorizationFragment. (That class does not yet exist. It will be
-                    // similar to ITMGeolocationFragment.
+                (authorizationClient as? ITMAuthorizationClient)?.let { authorizationClient ->
+                    fragmentActivity.supportFragmentManager.commit {
+                        setReorderingAllowed(true)
+                        val frag = createAuthorizationFragment(authorizationClient)
+                        add(fragmentContainerId, frag)
+                        authorizationFragment = frag
+                    }
                 }
                 frontendInitTask.complete()
             } catch (e: Exception) {
@@ -711,6 +721,18 @@ abstract class ITMApplication(
         return ITMGeolocationFragment(geolocationManager)
     }
 
+    /**
+     * Creates the [ITMAuthorizationFragment] to be used for this iTwin Mobile web app.
+     *
+     * Override this function in a subclass in order to add custom behavior.
+     *
+     * @param client The [ITMAuthorizationClient] to use with the fragment.
+     *
+     * @return And instance of [ITMAuthorizationFragment] attached to [client].
+     */
+    open fun createAuthorizationFragment(client: ITMAuthorizationClient): ITMAuthorizationFragment {
+        return ITMAuthorizationFragment(client)
+    }
 //    private fun loadFrontend() {
 //        val host = this.host ?: return
 //        MainScope().launch {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
@@ -136,7 +136,7 @@ abstract class ITMApplication(
      * The fragment used to present a sign in UI to the user.
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    protected var authorizationFragment: ITMAuthorizationFragment? = null
+    protected var authorizationFragment: ITMOIDCAuthorizationFragment? = null
 
     /**
      * The AuthorizationClient used for authentication.
@@ -245,10 +245,10 @@ abstract class ITMApplication(
      *
      *     | Key                                 | Description                                                                                           |
      *     |-------------------------------------|-------------------------------------------------------------------------------------------------------|
-     *     | ITMAPPLICATION_CLIENT_ID            | ITMAuthorizationClient required value containing the app's client ID.                                 |
-     *     | ITMAPPLICATION_SCOPE                | ITMAuthorizationClient required value containing the app's scope.                                     |
-     *     | ITMAPPLICATION_ISSUER_UR            | ITMAuthorizationClient optional value containing the app's issuer URL.                                |
-     *     | ITMAPPLICATION_REDIRECT_URI         | ITMAuthorizationClient optional value containing the app's redirect URL.                              |
+     *     | ITMAPPLICATION_CLIENT_ID            | ITMOIDCAuthorizationClient required value containing the app's client ID.                                 |
+     *     | ITMAPPLICATION_SCOPE                | ITMOIDCAuthorizationClient required value containing the app's scope.                                     |
+     *     | ITMAPPLICATION_ISSUER_UR            | ITMOIDCAuthorizationClient optional value containing the app's issuer URL.                                |
+     *     | ITMAPPLICATION_REDIRECT_URI         | ITMOIDCAuthorizationClient optional value containing the app's redirect URL.                              |
      *     | ITMAPPLICATION_MESSAGE_LOGGING      | Set to YES to have ITMMessenger log message traffic between JavaScript and Swift.                     |
      *     | ITMAPPLICATION_FULL_MESSAGE_LOGGING | Set to YES to include full message data in the ITMMessenger message logs. (DO NOT USE IN PRODUCTION.) |
      *
@@ -369,7 +369,7 @@ abstract class ITMApplication(
                         geolocationFragment = frag
                     }
                 }
-                (authorizationClient as? ITMAuthorizationClient)?.let { authorizationClient ->
+                (authorizationClient as? ITMOIDCAuthorizationClient)?.let { authorizationClient ->
                     fragmentActivity.supportFragmentManager.commit {
                         setReorderingAllowed(true)
                         val frag = createAuthorizationFragment(authorizationClient)
@@ -703,7 +703,7 @@ abstract class ITMApplication(
      */
     open fun createAuthorizationClient(): AuthorizationClient? {
         configData?.let { configData ->
-            return ITMAuthorizationClient(this, configData)
+            return ITMOIDCAuthorizationClient(this, configData)
         }
         return null
     }
@@ -722,16 +722,16 @@ abstract class ITMApplication(
     }
 
     /**
-     * Creates the [ITMAuthorizationFragment] to be used for this iTwin Mobile web app.
+     * Creates the [ITMOIDCAuthorizationFragment] to be used for this iTwin Mobile web app.
      *
      * Override this function in a subclass in order to add custom behavior.
      *
-     * @param client The [ITMAuthorizationClient] to use with the fragment.
+     * @param client The [ITMOIDCAuthorizationClient] to use with the fragment.
      *
-     * @return And instance of [ITMAuthorizationFragment] attached to [client].
+     * @return And instance of [ITMOIDCAuthorizationFragment] attached to [client].
      */
-    open fun createAuthorizationFragment(client: ITMAuthorizationClient): ITMAuthorizationFragment {
-        return ITMAuthorizationFragment(client)
+    open fun createAuthorizationFragment(client: ITMOIDCAuthorizationClient): ITMOIDCAuthorizationFragment {
+        return ITMOIDCAuthorizationFragment(client)
     }
 //    private fun loadFrontend() {
 //        val host = this.host ?: return

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
@@ -728,7 +728,7 @@ abstract class ITMApplication(
      * Override this function in a subclass in order to add custom behavior.
      *
      * __Note:__ If your [AuthorizationClient] is not a subclass of [ITMAuthorizationClient], this function
-     * will never be called. If you need a fragment to go with it, you are reponsible for setting it up yourself.
+     * will never be called. If you need a fragment to go with it, you are responsible for setting it up yourself.
      * If your [AuthorizationClient] _is_ a subclass of [ITMAuthorizationClient], then the [client] param
      * passed here will be an instance of that class.
      *

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
@@ -133,7 +133,7 @@ abstract class ITMApplication(
     protected var geolocationFragment: ITMGeolocationFragment? = null
 
     /**
-     * The fragment used to present a sign in UI to the user.
+     * The fragment used to present a signin UI to the user.
      */
     @Suppress("MemberVisibilityCanBePrivate")
     protected var authorizationFragment: ITMAuthorizationFragment? = null

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationClient.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationClient.kt
@@ -1,0 +1,13 @@
+package com.github.itwin.mobilesdk
+
+import com.bentley.itwin.AuthorizationClient
+import com.eclipsesource.json.JsonObject
+
+abstract class ITMAuthorizationClient(
+    @Suppress("unused") val itmApplication: ITMApplication,
+    @Suppress("unused") protected val configData: JsonObject): AuthorizationClient() {
+    protected var fragment: ITMAuthorizationFragment? = null
+    open fun setAuthorizationFragment(value: ITMAuthorizationFragment?) {
+        fragment = value
+    }
+}

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationClient.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationClient.kt
@@ -21,7 +21,16 @@ class ITMAuthorizationClient(@Suppress("unused") val itmApplication: ITMApplicat
 
     override fun getAccessToken(completion: AuthTokenCompletionAction) {
         MainScope().launch {
-            completion.resolve(null, null)
+            // Right now the frontend asks for a token when trying to send a message to the backend.
+            // That token is totally unused by the backend, so we can simply fail all requests that
+            // happen before the frontend launch has completed.
+            // We don't want to make any actual token requests until the user does something that
+            // requires a token.
+            if (itmApplication.messenger?.isFrontendLaunchComplete == true) {
+                completion.resolve("Bearer <TOKEN GOES HERE>", "<ISO 8601 Date String GOES HERE>")
+            } else {
+                completion.resolve(null, null)
+            }
         }
     }
 }

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationClient.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationClient.kt
@@ -3,10 +3,32 @@ package com.github.itwin.mobilesdk
 import com.bentley.itwin.AuthorizationClient
 import com.eclipsesource.json.JsonObject
 
+/**
+ * Abstract subclass of [AuthorizationClient] that includes a fragment for presenting a signin UI to
+ * the user. If you return an instance of a subclass of this class from [ITMApplication.createAuthorizationClient],
+ * [ITMApplication.createAuthorizationFragment] to create a related [ITMAuthorizationFragment].
+ *
+ * @param itmApplication The [ITMApplication] that will be needing authorization.
+ * @param configData A JSON object containing app-specific config data that may be needed by the
+ * authorization client.
+ */
 abstract class ITMAuthorizationClient(
     @Suppress("unused") val itmApplication: ITMApplication,
     @Suppress("unused") protected val configData: JsonObject): AuthorizationClient() {
+
+    /**
+     * The [ITMAuthorizationFragment] that is used to present the signin UI to the user.
+     */
     protected var fragment: ITMAuthorizationFragment? = null
+
+    /**
+     * Sets [fragment] to the given value.
+     *
+     * You must call this with `null` in the [onDestroy][androidx.fragment.app.Fragment.onDestroy]
+     * of your [ITMAuthorizationFragment].
+     *
+     * @param value The new value for [fragment].
+     */
     open fun setAuthorizationFragment(value: ITMAuthorizationFragment?) {
         fragment = value
     }

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationClient.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationClient.kt
@@ -1,0 +1,27 @@
+package com.github.itwin.mobilesdk
+
+import com.bentley.itwin.AuthTokenCompletionAction
+import com.bentley.itwin.AuthorizationClient
+import com.eclipsesource.json.JsonObject
+import com.github.itwin.mobilesdk.jsonvalue.getOptionalString
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+
+data class ITMAuthSettings(val issuerUrl: String, val clientId: String, val redirectUrl: String, val scope: String)
+
+class ITMAuthorizationClient(@Suppress("unused") val itmApplication: ITMApplication, configData: JsonObject): AuthorizationClient() {
+    private val authSettings: ITMAuthSettings
+    init {
+        val issuerUrl = configData.getOptionalString("ITMAPPLICATION_ISSUER_URL") ?: "https://ims.bentley.com/"
+        val clientId = configData.getOptionalString("ITMAPPLICATION_CLIENT_ID") ?: ""
+        val redirectUrl = configData.getOptionalString("ITMAPPLICATION_REDIRECT_URI") ?: "imodeljs://app/signin-callback"
+        val scope = configData.getOptionalString("ITMAPPLICATION_SCOPE") ?: "email openid profile organization itwinjs"
+        authSettings = ITMAuthSettings(issuerUrl, clientId, redirectUrl, scope)
+    }
+
+    override fun getAccessToken(completion: AuthTokenCompletionAction) {
+        MainScope().launch {
+            completion.resolve(null, null)
+        }
+    }
+}

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationFragment.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationFragment.kt
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+package com.github.itwin.mobilesdk
+
+import android.app.AlertDialog
+import android.os.Build
+import androidx.fragment.app.Fragment
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.*
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * [Fragment] used to present the signin UI for [ITMAuthorizationClient].
+ *
+ * @param client The [ITMAuthorizationClient] with which this fragment is associated.
+ */
+open class ITMAuthorizationFragment(private val client: ITMAuthorizationClient): Fragment() {
+    /**
+     * Data class to hold a token string and its expiration date.
+     *
+     * @property token The token string. Should have a "Bearer " prefix, followed by a Base64-encoded token.
+     * @property expirationDate The expiration date of the token, in ISO 8601 format.
+     */
+    data class AccessToken(val token: String? = null, val expirationDate: String? = null)
+
+    /**
+     * The last cached [AccessToken], or null if one hasn't been fetched.
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    protected var cachedToken: AccessToken? = null
+
+    init {
+        @Suppress("LeakingThis")
+        client.setAuthorizationFragment(this)
+    }
+
+    /**
+     * Determine if we have a non-expired cached token.
+     *
+     * @return true if we have a non-expired cached token, or false otherwise.
+     */
+    open fun haveCachedToken(): Boolean {
+        cachedToken?.expirationDate?.let { expirationDateString ->
+            val expirationDate = expirationDateString.iso8601ToDate() ?: return false
+            return Date().time < expirationDate.time
+        }
+        return false
+    }
+
+    /**
+     * Coroutine to present a signin UI to the user and return an access token. If a cached token
+     * exists, that should be directly returned instead of asking the user to sign in again.
+     */
+    open suspend fun getAccessToken(): AccessToken {
+        return suspendCoroutine { continuation ->
+            if (haveCachedToken()) {
+                continuation.resume(cachedToken!!)
+            } else {
+                with(AlertDialog.Builder(context)) {
+                    setTitle("Auth Stub")
+                    setMessage("issuerUrl: " + client.authSettings.issuerUrl)
+                    setPositiveButton("OK") { _, _ ->
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            val expireInUtc = OffsetDateTime.now(ZoneOffset.UTC).plusMinutes(1)
+                            cachedToken = AccessToken(
+                                "Bearer <TOKEN GOES HERE>",
+                                expireInUtc.format(DateTimeFormatter.ISO_DATE_TIME)
+                            )
+                            continuation.resume(cachedToken!!)
+                        } else {
+                            continuation.resume(AccessToken())
+                        }
+                    }
+                    setOnCancelListener {
+                        continuation.resume(AccessToken())
+                    }
+                    show()
+                }
+            }
+        }
+    }
+
+    /**
+     * Clean up by removing ourself from [client].
+     */
+    override fun onDestroy() {
+        super.onDestroy()
+        client.setAuthorizationFragment(null)
+    }
+}

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationFragment.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationFragment.kt
@@ -6,6 +6,8 @@ import java.util.*
 /**
  * Abstract base class for a [Fragment] used to present the signin UI for [ITMAuthorizationClient].
  *
+ * __Note:__ The constructor automatically attaches this instance to [client].
+ *
  * @param client The [ITMAuthorizationClient] with which this fragment is associated.
  */
 abstract class ITMAuthorizationFragment(protected val client: ITMAuthorizationClient): Fragment() {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationFragment.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAuthorizationFragment.kt
@@ -1,0 +1,48 @@
+package com.github.itwin.mobilesdk
+
+import androidx.fragment.app.Fragment
+import java.util.*
+
+/**
+ * Abstract base class for a [Fragment] used to present the signin UI for [ITMAuthorizationClient].
+ *
+ * @param client The [ITMAuthorizationClient] with which this fragment is associated.
+ */
+abstract class ITMAuthorizationFragment(protected val client: ITMAuthorizationClient): Fragment() {
+    /**
+     * Data class to hold a token string and its expiration date.
+     *
+     * @property token The token string. Should have a "Bearer " prefix, followed by a Base64-encoded token.
+     * @property expirationDate The expiration date of the token, in ISO 8601 format.
+     */
+    data class AccessToken(val token: String? = null, val expirationDate: String? = null)
+
+    /**
+     * The last cached [AccessToken], or null if one hasn't been fetched.
+     */
+    protected var cachedToken: AccessToken? = null
+
+    /**
+     * Determine if we have a non-expired cached token.
+     *
+     * @return true if we have a non-expired cached token, or false otherwise.
+     */
+    open fun haveCachedToken(): Boolean {
+        cachedToken?.expirationDate?.let { expirationDateString ->
+            val expirationDate = expirationDateString.iso8601ToDate() ?: return false
+            return Date().time < expirationDate.time
+        }
+        return false
+    }
+
+    init {
+        @Suppress("LeakingThis")
+        client.setAuthorizationFragment(this)
+    }
+
+    /**
+     * Coroutine to present a signin UI to the user and return an access token. If a cached token
+     * exists, that should be directly returned instead of asking the user to sign in again.
+     */
+    abstract suspend fun getAccessToken(): AccessToken
+}

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMCoMessenger.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMCoMessenger.kt
@@ -93,6 +93,13 @@ open class ITMCoMessenger(private val messenger: ITMMessenger) {
     }
 
     /**
+     * Convenience wrapper around [ITMMessenger.isFrontendLaunchComplete].
+     */
+    @Suppress("unused")
+    open val isFrontendLaunchComplete: Boolean
+        get() = messenger.isFrontendLaunchComplete
+
+    /**
      * Convenience wrapper around [ITMMessenger.frontendLaunchFailed].
      */
     open fun frontendLaunchFailed(exception: Exception) {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMDatePicker.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMDatePicker.kt
@@ -77,7 +77,7 @@ class ITMDatePicker(nativeUI: ITMNativeUI): ITMNativeUIComponent(nativeUI)  {
 }
 
 /**
- * Convenience function to convert string containing an ISO 8601 date into a [Date] object.
+ * Convenience function to convert a [String] containing an ISO 8601 date into a [Date] object.
  *
  * @return The parsed [Date], or null if the receiver string could not be parsed into a valid [Date].
  */

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationFragment.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationFragment.kt
@@ -12,8 +12,11 @@ import androidx.activity.result.contract.ActivityResultContracts
 /**
  * [Fragment] used by [ITMGeolocationManager] to present location access permissions requests to the user.
  */
-open class ITMGeolocationFragment : Fragment() {
-    private var geolocationManager: ITMGeolocationManager? = null
+open class ITMGeolocationFragment(private val geolocationManager: ITMGeolocationManager) : Fragment() {
+    init {
+        @Suppress("LeakingThis")
+        geolocationManager.setGeolocationFragment(this)
+    }
 
     /**
      * [ActivityResultLauncher][androidx.activity.result.ActivityResultLauncher] used to request location permissions.
@@ -23,9 +26,9 @@ open class ITMGeolocationFragment : Fragment() {
      */
     val requestPermission = registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
         if (isGranted) {
-            geolocationManager?.onLocationPermissionGranted()
+            geolocationManager.onLocationPermissionGranted()
         } else {
-            geolocationManager?.onLocationPermissionDenied()
+            geolocationManager.onLocationPermissionDenied()
             Toast.makeText(requireContext(), getString(R.string.location_permissions_error_toast_text), Toast.LENGTH_LONG).show()
         }
     }
@@ -38,19 +41,10 @@ open class ITMGeolocationFragment : Fragment() {
      */
     val requestLocationService = registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { activityResult ->
         if (activityResult.resultCode == Activity.RESULT_OK) {
-            geolocationManager?.onLocationServiceEnabled()
+            geolocationManager.onLocationServiceEnabled()
         } else {
-            geolocationManager?.onLocationServiceEnableRequestDenied()
+            geolocationManager.onLocationServiceEnableRequestDenied()
         }
-    }
-
-    /**
-     * Set the [ITMGeolocationManager] to which this fragment is attached.
-     */
-    @Suppress("unused")
-    open fun setGeolocationManager(geolocationManager: ITMGeolocationManager) {
-        this.geolocationManager = geolocationManager
-        geolocationManager.setGeolocationFragment(this)
     }
 
     /**
@@ -58,7 +52,7 @@ open class ITMGeolocationFragment : Fragment() {
      */
     override fun onStart() {
         super.onStart()
-        geolocationManager?.resumeLocationUpdates()
+        geolocationManager.resumeLocationUpdates()
     }
 
     /**
@@ -66,6 +60,14 @@ open class ITMGeolocationFragment : Fragment() {
      */
     override fun onStop() {
         super.onStop()
-        geolocationManager?.stopLocationUpdates()
+        geolocationManager.stopLocationUpdates()
+    }
+
+    /**
+     * Removes this fragment from [geolocationManager].
+     */
+    override fun onDestroy() {
+        super.onDestroy()
+        geolocationManager.setGeolocationFragment(null)
     }
 }

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
@@ -36,7 +36,7 @@ import kotlin.concurrent.schedule
  * Class for the native-side implementation of a `navigator.geolocation` polyfill.
  *
  * __Note:__ [ITMGeolocationManager] must be bound to an [ITMGeolocationFragment]-based fragment for showing permission
- * and service dialogs and handling responses. Bind using [ITMGeolocationFragment.setGeolocationManager].
+ * and service dialogs and handling responses. This happens automatically in the [ITMGeolocationFragment] constructor.
  */
 class ITMGeolocationManager(private val appContext: Context, private val webView: WebView) {
     private inner class GeolocationJsInterface {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMMessenger.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMMessenger.kt
@@ -413,6 +413,12 @@ open class ITMMessenger(private val itmApplication: ITMApplication) {
     }
 
     /**
+     * Indicates if the frontend launch has completed.
+     */
+    open val isFrontendLaunchComplete: Boolean
+        get() = frontendLaunchJob.isCompleted
+
+    /**
      * Called if the frontend fails to launch. This prevents any queries from being sent to the web view.
      *
      * @param exception The reason for the failure.

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationClient.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationClient.kt
@@ -4,13 +4,14 @@
 *--------------------------------------------------------------------------------------------*/
 package com.github.itwin.mobilesdk
 
+import android.net.Uri
 import com.bentley.itwin.AuthTokenCompletionAction
 import com.eclipsesource.json.JsonObject
 import com.github.itwin.mobilesdk.jsonvalue.getOptionalString
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 
-data class ITMAuthSettings(val issuerUrl: String, val clientId: String, val redirectUrl: String, val scope: String)
+data class ITMAuthSettings(val issuerUri: Uri, val clientId: String, val redirectUri: Uri, val scope: String)
 
 open class ITMOIDCAuthorizationClient(itmApplication: ITMApplication, configData: JsonObject):
     ITMAuthorizationClient(itmApplication, configData) {
@@ -20,7 +21,7 @@ open class ITMOIDCAuthorizationClient(itmApplication: ITMApplication, configData
         val clientId = configData.getOptionalString("ITMAPPLICATION_CLIENT_ID") ?: ""
         val redirectUrl = configData.getOptionalString("ITMAPPLICATION_REDIRECT_URI") ?: "imodeljs://app/signin-callback"
         val scope = configData.getOptionalString("ITMAPPLICATION_SCOPE") ?: "email openid profile organization itwinjs"
-        authSettings = ITMAuthSettings(issuerUrl, clientId, redirectUrl, scope)
+        authSettings = ITMAuthSettings(Uri.parse(issuerUrl), clientId, Uri.parse(redirectUrl), scope)
     }
 
     override fun getAccessToken(completion: AuthTokenCompletionAction) {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationClient.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationClient.kt
@@ -13,9 +13,9 @@ import kotlinx.coroutines.launch
 
 data class ITMAuthSettings(val issuerUrl: String, val clientId: String, val redirectUrl: String, val scope: String)
 
-open class ITMAuthorizationClient(@Suppress("unused") val itmApplication: ITMApplication, configData: JsonObject): AuthorizationClient() {
+open class ITMOIDCAuthorizationClient(@Suppress("unused") val itmApplication: ITMApplication, configData: JsonObject): AuthorizationClient() {
     val authSettings: ITMAuthSettings
-    private var fragment: ITMAuthorizationFragment? = null
+    private var fragment: ITMOIDCAuthorizationFragment? = null
     init {
         val issuerUrl = configData.getOptionalString("ITMAPPLICATION_ISSUER_URL") ?: "https://ims.bentley.com/"
         val clientId = configData.getOptionalString("ITMAPPLICATION_CLIENT_ID") ?: ""
@@ -24,7 +24,7 @@ open class ITMAuthorizationClient(@Suppress("unused") val itmApplication: ITMApp
         authSettings = ITMAuthSettings(issuerUrl, clientId, redirectUrl, scope)
     }
 
-    open fun setAuthorizationFragment(value: ITMAuthorizationFragment?) {
+    open fun setAuthorizationFragment(value: ITMOIDCAuthorizationFragment?) {
         fragment = value
     }
 

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationClient.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationClient.kt
@@ -13,6 +13,23 @@ import kotlinx.coroutines.launch
 
 data class ITMAuthSettings(val issuerUri: Uri, val clientId: String, val redirectUri: Uri, val scope: String)
 
+/**
+ * [ITMAuthorizationClient] subclass that is used to perform authorization via OIDC in conjunction with
+ * [ITMOIDCAuthorizationFragment] to present the UI to the user.
+ *
+ * In order to use this, you must add the following to the `defaultConfig` section of the `android` section
+ * of your app's build.gradle:
+ *
+ * ```
+ *     manifestPlaceholders = ['appAuthRedirectScheme': 'imodeljs']
+ * ```
+ *
+ * @param itmApplication The [ITMApplication] that will be needing authorization.
+ * @param configData A JSON object containing at least an `ITMAPPLICATION_CLIENT_ID` value, and optionally
+ * `ITMAPPLICATION_ISSUER_URL`, `ITMAPPLICATION_REDIRECT_URI`, and/or `ITMAPPLICATION_SCOPE` values. If
+ * `ITMAPPLICATION_CLIENT_ID` is not present this initializer will fail. This is be populated by
+ * [ITMApplication.loadITMAppConfig].
+ */
 open class ITMOIDCAuthorizationClient(itmApplication: ITMApplication, configData: JsonObject):
     ITMAuthorizationClient(itmApplication, configData) {
     val authSettings: ITMAuthSettings
@@ -24,6 +41,13 @@ open class ITMOIDCAuthorizationClient(itmApplication: ITMApplication, configData
         authSettings = ITMAuthSettings(Uri.parse(issuerUrl), clientId, Uri.parse(redirectUrl), scope)
     }
 
+    /**
+     * Function that is called by the iTwin backend to get an access token, along with its expiration date.
+     *
+     * @param completion Action that will have resolve called with the token and expiration date, or null values if
+     * a token is not available. Note that the `expirationDate` parameter of `resolve` is expected to be an ISO
+     * 8601 date string.
+     */
     override fun getAccessToken(completion: AuthTokenCompletionAction) {
         MainScope().launch {
             // Right now the frontend asks for a token when trying to send a message to the backend.

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationClient.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationClient.kt
@@ -5,7 +5,6 @@
 package com.github.itwin.mobilesdk
 
 import com.bentley.itwin.AuthTokenCompletionAction
-import com.bentley.itwin.AuthorizationClient
 import com.eclipsesource.json.JsonObject
 import com.github.itwin.mobilesdk.jsonvalue.getOptionalString
 import kotlinx.coroutines.MainScope
@@ -13,19 +12,15 @@ import kotlinx.coroutines.launch
 
 data class ITMAuthSettings(val issuerUrl: String, val clientId: String, val redirectUrl: String, val scope: String)
 
-open class ITMOIDCAuthorizationClient(@Suppress("unused") val itmApplication: ITMApplication, configData: JsonObject): AuthorizationClient() {
+open class ITMOIDCAuthorizationClient(itmApplication: ITMApplication, configData: JsonObject):
+    ITMAuthorizationClient(itmApplication, configData) {
     val authSettings: ITMAuthSettings
-    private var fragment: ITMOIDCAuthorizationFragment? = null
     init {
         val issuerUrl = configData.getOptionalString("ITMAPPLICATION_ISSUER_URL") ?: "https://ims.bentley.com/"
         val clientId = configData.getOptionalString("ITMAPPLICATION_CLIENT_ID") ?: ""
         val redirectUrl = configData.getOptionalString("ITMAPPLICATION_REDIRECT_URI") ?: "imodeljs://app/signin-callback"
         val scope = configData.getOptionalString("ITMAPPLICATION_SCOPE") ?: "email openid profile organization itwinjs"
         authSettings = ITMAuthSettings(issuerUrl, clientId, redirectUrl, scope)
-    }
-
-    open fun setAuthorizationFragment(value: ITMOIDCAuthorizationFragment?) {
-        fragment = value
     }
 
     override fun getAccessToken(completion: AuthTokenCompletionAction) {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationFragment.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationFragment.kt
@@ -15,11 +15,11 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 /**
- * [Fragment] used to present the signin UI for [ITMAuthorizationClient].
+ * [Fragment] used to present the signin UI for [ITMOIDCAuthorizationClient].
  *
- * @param client The [ITMAuthorizationClient] with which this fragment is associated.
+ * @param client The [ITMOIDCAuthorizationClient] with which this fragment is associated.
  */
-open class ITMAuthorizationFragment(private val client: ITMAuthorizationClient): Fragment() {
+open class ITMOIDCAuthorizationFragment(private val client: ITMOIDCAuthorizationClient): Fragment() {
     /**
      * Data class to hold a token string and its expiration date.
      *

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationFragment.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationFragment.kt
@@ -10,60 +10,27 @@ import androidx.fragment.app.Fragment
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
-import java.util.*
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 /**
  * [Fragment] used to present the signin UI for [ITMOIDCAuthorizationClient].
  *
- * @param client The [ITMOIDCAuthorizationClient] with which this fragment is associated.
+ * @param oidcClient The [ITMOIDCAuthorizationClient] with which this fragment is associated.
  */
-open class ITMOIDCAuthorizationFragment(private val client: ITMOIDCAuthorizationClient): Fragment() {
-    /**
-     * Data class to hold a token string and its expiration date.
-     *
-     * @property token The token string. Should have a "Bearer " prefix, followed by a Base64-encoded token.
-     * @property expirationDate The expiration date of the token, in ISO 8601 format.
-     */
-    data class AccessToken(val token: String? = null, val expirationDate: String? = null)
-
-    /**
-     * The last cached [AccessToken], or null if one hasn't been fetched.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
-    protected var cachedToken: AccessToken? = null
-
-    init {
-        @Suppress("LeakingThis")
-        client.setAuthorizationFragment(this)
-    }
-
-    /**
-     * Determine if we have a non-expired cached token.
-     *
-     * @return true if we have a non-expired cached token, or false otherwise.
-     */
-    open fun haveCachedToken(): Boolean {
-        cachedToken?.expirationDate?.let { expirationDateString ->
-            val expirationDate = expirationDateString.iso8601ToDate() ?: return false
-            return Date().time < expirationDate.time
-        }
-        return false
-    }
-
+open class ITMOIDCAuthorizationFragment(private val oidcClient: ITMOIDCAuthorizationClient): ITMAuthorizationFragment(oidcClient) {
     /**
      * Coroutine to present a signin UI to the user and return an access token. If a cached token
      * exists, that should be directly returned instead of asking the user to sign in again.
      */
-    open suspend fun getAccessToken(): AccessToken {
+    override suspend fun getAccessToken(): AccessToken {
         return suspendCoroutine { continuation ->
             if (haveCachedToken()) {
                 continuation.resume(cachedToken!!)
             } else {
                 with(AlertDialog.Builder(context)) {
                     setTitle("Auth Stub")
-                    setMessage("issuerUrl: " + client.authSettings.issuerUrl)
+                    setMessage("issuerUrl: " + oidcClient.authSettings.issuerUrl)
                     setPositiveButton("OK") { _, _ ->
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                             val expireInUtc = OffsetDateTime.now(ZoneOffset.UTC).plusMinutes(1)

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationFragment.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationFragment.kt
@@ -132,6 +132,7 @@ open class ITMOIDCAuthorizationFragment(oidcClient: ITMOIDCAuthorizationClient):
             resume(AccessToken())
         }
     }
+
     /**
      * Clean up by removing ourself from [client].
      */
@@ -141,6 +142,12 @@ open class ITMOIDCAuthorizationFragment(oidcClient: ITMOIDCAuthorizationClient):
     }
 }
 
+/**
+ * Convenience function convert a [Long] containing the number of milliseconds since the epoch into an
+ * ISO 8601-formatted [String].
+ *
+ * @return A [String] containing an ISO 8601 format date.
+ */
 fun Long.epochMillisToISO8601(): String {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         Instant.ofEpochMilli(this).toString()

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationFragment.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationFragment.kt
@@ -4,59 +4,150 @@
 *--------------------------------------------------------------------------------------------*/
 package com.github.itwin.mobilesdk
 
-import android.app.AlertDialog
+import android.app.Activity
+import android.content.Intent
 import android.os.Build
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
+import net.openid.appauth.*
+import java.text.SimpleDateFormat
+import java.time.Instant
+import java.util.*
+import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+
 
 /**
  * [Fragment] used to present the signin UI for [ITMOIDCAuthorizationClient].
  *
+ * In order to use this, you must add the following to the `defaultConfig` section of the `android` section
+ * of your app's build.gradle:
+ *
+ * ```
+ *     manifestPlaceholders = ['appAuthRedirectScheme': 'imodeljs']
+ * ```
+ *
  * @param oidcClient The [ITMOIDCAuthorizationClient] with which this fragment is associated.
  */
-open class ITMOIDCAuthorizationFragment(private val oidcClient: ITMOIDCAuthorizationClient): ITMAuthorizationFragment(oidcClient) {
-    /**
-     * Coroutine to present a signin UI to the user and return an access token. If a cached token
-     * exists, that should be directly returned instead of asking the user to sign in again.
-     */
-    override suspend fun getAccessToken(): AccessToken {
+open class ITMOIDCAuthorizationFragment(oidcClient: ITMOIDCAuthorizationClient): ITMAuthorizationFragment(oidcClient) {
+    private val authSettings = oidcClient.authSettings
+    private var authState: AuthState? = null
+    private var authService: AuthorizationService? = null
+    private var continuation: Continuation<AccessToken>? = null
+
+    private suspend fun initAuthState(): AuthState {
+        authState?.let { authState ->
+            return authState
+        }
         return suspendCoroutine { continuation ->
-            if (haveCachedToken()) {
-                continuation.resume(cachedToken!!)
-            } else {
-                with(AlertDialog.Builder(context)) {
-                    setTitle("Auth Stub")
-                    setMessage("issuerUrl: " + oidcClient.authSettings.issuerUrl)
-                    setPositiveButton("OK") { _, _ ->
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                            val expireInUtc = OffsetDateTime.now(ZoneOffset.UTC).plusMinutes(1)
-                            cachedToken = AccessToken(
-                                "Bearer <TOKEN GOES HERE>",
-                                expireInUtc.format(DateTimeFormatter.ISO_DATE_TIME)
-                            )
-                            continuation.resume(cachedToken!!)
-                        } else {
-                            continuation.resume(AccessToken())
-                        }
-                    }
-                    setOnCancelListener {
-                        continuation.resume(AccessToken())
-                    }
-                    show()
+            AuthorizationServiceConfiguration.fetchFromIssuer(authSettings.issuerUri) { config, error ->
+                @Suppress("NAME_SHADOWING")
+                error?.let { error ->
+                    client.itmApplication.logger.log(
+                        ITMLogger.Severity.Warning,
+                        "Error fetching OIDC service config: $error"
+                    )
+                    throw error
+                } ?: config?.let { config ->
+                    val authState = AuthState(config)
+                    this.authState = authState
+                    continuation.resume(authState)
                 }
             }
         }
     }
 
+    private fun resume(accessToken: AccessToken) {
+        continuation?.resume(accessToken)
+        continuation = null
+    }
+
+    private fun launchRequestAuthorization(authState: AuthState) {
+        val authReqBuilder = AuthorizationRequest.Builder(
+            authState.authorizationServiceConfiguration!!,
+            authSettings.clientId,
+            ResponseTypeValues.CODE,
+            authSettings.redirectUri
+        )
+        authReqBuilder.setScope(authSettings.scope)
+            .setCodeVerifier(CodeVerifierUtil.generateRandomCodeVerifier())
+        if (authService == null) {
+            authService = AuthorizationService(requireContext())
+        }
+        authService!!.getAuthorizationRequestIntent(authReqBuilder.build())?.let { intent ->
+            requestAuthorization.launch(intent)
+        } ?: resume(AccessToken())
+    }
+
+    /**
+     * Coroutine to present a signin UI to the user and return an access token. If a cached token
+     * exists, that should be directly returned instead of asking the user to sign in again.
+     */
+    override suspend fun getAccessToken(): AccessToken {
+        return if (haveCachedToken()) {
+            cachedToken!!
+        } else {
+            try {
+                val authState = initAuthState()
+                suspendCoroutine { continuation ->
+                    this.continuation = continuation
+                    launchRequestAuthorization(authState)
+                }
+            } catch (ex: Exception) {
+                AccessToken()
+            }
+        }
+    }
+
+    private fun handleAuthorizationResponse(data: Intent) {
+        val response = AuthorizationResponse.fromIntent(data)
+        val ex = AuthorizationException.fromIntent(data)
+
+        if (response == null) {
+            resume(AccessToken())
+            return
+        }
+        authState?.let { authState ->
+            authState.update(response, ex)
+            authService?.performTokenRequest(response.createTokenExchangeRequest()) { response, ex ->
+                authState.update(response, ex)
+                val accessToken = if (authState.isAuthorized) {
+                    AccessToken("Bearer ${authState.accessToken}", authState.accessTokenExpirationTime?.epochMillisToISO8601())
+                } else {
+                    AccessToken()
+                }
+                cachedToken = accessToken
+                resume(accessToken)
+            }
+        }
+    }
+
+    private var requestAuthorization = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            result.data?.let { data ->
+                handleAuthorizationResponse(data)
+            } ?: resume(AccessToken())
+        } else {
+            resume(AccessToken())
+        }
+    }
     /**
      * Clean up by removing ourself from [client].
      */
     override fun onDestroy() {
         super.onDestroy()
         client.setAuthorizationFragment(null)
+    }
+}
+
+fun Long.epochMillisToISO8601(): String {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        Instant.ofEpochMilli(this).toString()
+    } else {
+        val epochDate = Date(this)
+        @Suppress("SpellCheckingInspection")
+        val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.getDefault())
+        return sdf.format(epochDate)
     }
 }


### PR DESCRIPTION
Unfortunately, the latest Android add-on does not yet contain the auth refactor necessary to make this work, so it only works with a local imodel02 build.