### PR TITLE
Use the system's dark mode settings for the webview

### DIFF
--- a/mobile-sdk/build.gradle
+++ b/mobile-sdk/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation "androidx.fragment:fragment-ktx:1.4.1"
+    implementation 'androidx.webkit:webkit:1.4.0'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.code.gson:gson:2.9.0'


### PR DESCRIPTION
The app will now use the system's dark mode setting on startup. 
I don't believe it is possible to detect changes without an activity, so I made a convenience function to reapply the preferredColorScheme. An upcoming PR for the sample app will use this to dynamically update the app as the theme changes.