### PR TITLE
Rename ITMMessenger listeners to handlers to match iOS API

### DIFF
--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMActionSheet.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMActionSheet.kt
@@ -41,7 +41,7 @@ class ITMActionSheet(nativeUI: ITMNativeUI): ITMNativeUIComponent(nativeUI) {
     private var continuation: Continuation<JsonValue>? = null
 
     init {
-        listener = coMessenger.addQueryListener("Bentley_ITM_presentActionSheet") { value -> handleQuery(value) }
+        handler = coMessenger.registerQueryHandler("Bentley_ITM_presentActionSheet") { value -> handleQuery(value) }
     }
 
     private suspend fun handleQuery(value: JsonValue?): JsonValue {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAlert.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMAlert.kt
@@ -64,7 +64,7 @@ class ITMAlert(nativeUI: ITMNativeUI): ITMNativeUIComponent(nativeUI)  {
     }
 
     init {
-        listener = coMessenger.addQueryListener("Bentley_ITM_presentAlert") { value -> handleQuery(value) }
+        handler = coMessenger.registerQueryHandler("Bentley_ITM_presentAlert") { value -> handleQuery(value) }
     }
 
     @Suppress("LongMethod")

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
@@ -532,7 +532,7 @@ abstract class ITMApplication(
             webViewLogger = ITMWebViewLogger(webView, ::onWebViewLog)
         }
         coMessenger = ITMCoMessenger(messenger!!)
-        messenger?.addMessageListener("Bentley_ITM_updatePreferredColorScheme") { value ->
+        messenger?.registerMessageHandler("Bentley_ITM_updatePreferredColorScheme") { value ->
             value?.asObject()?.getOptionalLong("preferredColorScheme")?.let { longValue ->
                 preferredColorScheme = PreferredColorScheme.fromLong(longValue) ?: PreferredColorScheme.Automatic
                 MainScope().launch {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMCoMessenger.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMCoMessenger.kt
@@ -49,23 +49,23 @@ open class ITMCoMessenger(private val messenger: ITMMessenger) {
     }
 
     /**
-     * Convenience wrapper around [ITMMessenger.addMessageListener]
+     * Convenience wrapper around [ITMMessenger.registerMessageHandler]
      */
     @Suppress("unused")
-    open fun addMessageListener(type: String, callback: ITMSuccessCallback): ITMMessenger.ITMListener {
-        return messenger.addMessageListener(type, callback)
+    open fun registerMessageHandler(type: String, callback: ITMSuccessCallback): ITMMessenger.ITMHandler {
+        return messenger.registerMessageHandler(type, callback)
     }
 
     /**
-     * Add a coroutine-based listener for queries from the [web view][ITMApplication.webView].
+     * Add a coroutine-based handler for queries from the [web view][ITMApplication.webView].
      *
      * @param type Query type.
      * @param callback Coroutine function to respond to the query. Throws in the case of error, otherwise optionally return a value.
      *
-     * @return The [ITMMessenger.ITMListener] value to subsequently pass into [removeListener].
+     * @return The [ITMMessenger.ITMHandler] value to subsequently pass into [removeHandler].
      */
-    open fun addQueryListener(type: String, callback: suspend (JsonValue?) -> JsonValue?): ITMMessenger.ITMListener {
-        return messenger.addQueryListener(type) { value, success, failure ->
+    open fun registerQueryHandler(type: String, callback: suspend (JsonValue?) -> JsonValue?): ITMMessenger.ITMHandler {
+        return messenger.registerQueryHandler(type) { value, success, failure ->
             MainScope().launch {
                 try {
                     val result = callback.invoke(value)
@@ -78,10 +78,10 @@ open class ITMCoMessenger(private val messenger: ITMMessenger) {
     }
 
     /**
-     * Convenience wrapper around [ITMMessenger.removeListener].
+     * Convenience wrapper around [ITMMessenger.removeHandler].
      */
-    open fun removeListener(listener: ITMMessenger.ITMListener?) {
-        messenger.removeListener(listener)
+    open fun removeHandler(handler: ITMMessenger.ITMHandler?) {
+        messenger.removeHandler(handler)
     }
 
     /**

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMDatePicker.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMDatePicker.kt
@@ -23,7 +23,7 @@ import kotlin.coroutines.suspendCoroutine
  */
 class ITMDatePicker(nativeUI: ITMNativeUI): ITMNativeUIComponent(nativeUI)  {
     init {
-        listener = coMessenger.addQueryListener("Bentley_ITM_presentDatePicker") { value -> handleQuery(value) }
+        handler = coMessenger.registerQueryHandler("Bentley_ITM_presentDatePicker") { value -> handleQuery(value) }
     }
 
     private fun getDateParam(params: JsonObject, field: String): Date? {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMNativeUIComponent.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMNativeUIComponent.kt
@@ -20,14 +20,14 @@ open class ITMNativeUIComponent(@Suppress("MemberVisibilityCanBePrivate") protec
     protected val context: Context = nativeUI.context
     protected val webView: WebView = nativeUI.webView
     protected val coMessenger: ITMCoMessenger = nativeUI.coMessenger
-    var listener: ITMMessenger.ITMListener? = null
+    var handler: ITMMessenger.ITMHandler? = null
 
     /**
      * Detach this UI component from the native UI (stop listening for messages).
      */
     open fun detach() {
-        coMessenger.removeListener(listener)
-        listener = null
+        coMessenger.removeHandler(handler)
+        handler = null
     }
 
     /**


### PR DESCRIPTION
__NOTE:__ This is not backwards compatible and requires updates to the sample apps. The only checked in sample will get a PR shortly.