### PR TITLE
Make messenger non-optional.

### DIFF
--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
@@ -398,7 +398,7 @@ abstract class ITMApplication(
                 if (usingRemoteServer) {
                     MainScope().launch {
                         delay(10000)
-                        if (messenger.isFrontendLaunchComplete) {
+                        if (!messenger.isFrontendLaunchComplete) {
                             with(AlertDialog.Builder(fragmentActivity)) {
                                 setTitle(R.string.itm_error)
                                 setMessage(fragmentActivity.getString(R.string.itm_debug_server_error, baseUrl))

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMCoMessenger.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMCoMessenger.kt
@@ -16,12 +16,12 @@ import kotlin.coroutines.suspendCoroutine
  *
  * @param messenger The [ITMMessenger] that this wraps.
  */
-open class ITMCoMessenger(private val messenger: ITMMessenger) {
+class ITMCoMessenger(private val messenger: ITMMessenger) {
     /**
      * Convenience wrapper around [ITMMessenger.send].
      */
     @Suppress("unused")
-    open fun send(type: String, data: JsonValue? = null) {
+    fun send(type: String, data: JsonValue? = null) {
         messenger.send(type, data)
     }
 
@@ -34,7 +34,7 @@ open class ITMCoMessenger(private val messenger: ITMMessenger) {
      * @return The result from the web app.
      */
     @Suppress("unused")
-    open suspend fun query(type: String, data: JsonValue? = null): JsonValue? {
+    suspend fun query(type: String, data: JsonValue? = null): JsonValue? {
         return suspendCoroutine { continuation ->
             try {
                 messenger.query(type, data, { data ->
@@ -52,7 +52,7 @@ open class ITMCoMessenger(private val messenger: ITMMessenger) {
      * Convenience wrapper around [ITMMessenger.registerMessageHandler]
      */
     @Suppress("unused")
-    open fun registerMessageHandler(type: String, callback: ITMSuccessCallback): ITMMessenger.ITMHandler {
+    fun registerMessageHandler(type: String, callback: ITMSuccessCallback): ITMMessenger.ITMHandler {
         return messenger.registerMessageHandler(type, callback)
     }
 
@@ -64,7 +64,7 @@ open class ITMCoMessenger(private val messenger: ITMMessenger) {
      *
      * @return The [ITMMessenger.ITMHandler] value to subsequently pass into [removeHandler].
      */
-    open fun registerQueryHandler(type: String, callback: suspend (JsonValue?) -> JsonValue?): ITMMessenger.ITMHandler {
+    fun registerQueryHandler(type: String, callback: suspend (JsonValue?) -> JsonValue?): ITMMessenger.ITMHandler {
         return messenger.registerQueryHandler(type) { value, success, failure ->
             MainScope().launch {
                 try {
@@ -80,7 +80,7 @@ open class ITMCoMessenger(private val messenger: ITMMessenger) {
     /**
      * Convenience wrapper around [ITMMessenger.removeHandler].
      */
-    open fun removeHandler(handler: ITMMessenger.ITMHandler?) {
+    fun removeHandler(handler: ITMMessenger.ITMHandler?) {
         messenger.removeHandler(handler)
     }
 
@@ -88,7 +88,7 @@ open class ITMCoMessenger(private val messenger: ITMMessenger) {
      * Convenience wrapper around [ITMMessenger.frontendLaunchSucceeded].
      */
     @Suppress("unused")
-    open fun frontendLaunchSucceeded() {
+    fun frontendLaunchSucceeded() {
         messenger.frontendLaunchSucceeded()
     }
 
@@ -96,13 +96,21 @@ open class ITMCoMessenger(private val messenger: ITMMessenger) {
      * Convenience wrapper around [ITMMessenger.isFrontendLaunchComplete].
      */
     @Suppress("unused")
-    open val isFrontendLaunchComplete: Boolean
+    val isFrontendLaunchComplete: Boolean
         get() = messenger.isFrontendLaunchComplete
 
     /**
      * Convenience wrapper around [ITMMessenger.frontendLaunchFailed].
      */
-    open fun frontendLaunchFailed(exception: Exception) {
+    fun frontendLaunchFailed(exception: Exception) {
         messenger.frontendLaunchFailed(exception)
+    }
+
+    /**
+     * Call to join the frontend launch job (wait for the frontend to launch).
+     */
+    @Suppress("unused")
+    suspend fun frontendLaunchJoin() {
+        messenger.frontendLaunchJob.join()
     }
 }

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationClient.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMOIDCAuthorizationClient.kt
@@ -55,7 +55,7 @@ open class ITMOIDCAuthorizationClient(itmApplication: ITMApplication, configData
             // happen before the frontend launch has completed.
             // We don't want to make any actual token requests until the user does something that
             // requires a token.
-            if (itmApplication.messenger?.isFrontendLaunchComplete == true) {
+            if (itmApplication.messenger.isFrontendLaunchComplete) {
                 val accessToken = fragment?.getAccessToken()
                 if (accessToken != null) {
                     completion.resolve(accessToken.token, accessToken.expirationDate)


### PR DESCRIPTION
Also make ITMMessanger and ITMCoMessenger final.

This refactor was done at the request of SYNCHRO Field to make their startup code much simpler.
There will be a separate PR in mobile-samples that updates that code to no longer treat ITMApplication's messenger and coMessenger as optional.
This also removes the open status of ITMMessenger and ITMCoMessenger, since the code in ITMApplication that made use of them didn't allow for them to be subclassed.