### PR TITLE
Messenger related updates

### DIFF
--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
@@ -535,12 +535,10 @@ abstract class ITMApplication(
         if (attachWebViewLogger) {
             webViewLogger = ITMWebViewLogger(webView, ::onWebViewLog)
         }
-        messenger.registerMessageHandler("Bentley_ITM_updatePreferredColorScheme") { value ->
+        messenger.registerQueryHandler("Bentley_ITM_updatePreferredColorScheme") { value, _, _ ->
             value?.asObject()?.getOptionalLong("preferredColorScheme")?.let { longValue ->
                 preferredColorScheme = PreferredColorScheme.fromLong(longValue) ?: PreferredColorScheme.Automatic
-                MainScope().launch {
-                    applyPreferredColorScheme()
-                }
+                applyPreferredColorScheme()
             }
         }
         webView.settings.setSupportZoom(false)

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMCoMessenger.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMCoMessenger.kt
@@ -58,10 +58,9 @@ class ITMCoMessenger(private val messenger: ITMMessenger) {
      */
     @Suppress("unused")
     fun registerMessageHandler(type: String, callback: suspend (JsonValue?) -> Unit): ITMMessenger.ITMHandler {
-        return messenger.registerMessageHandler(type) {
-            MainScope().launch {
-                callback.invoke(it)
-            }
+        return registerQueryHandler(type) { value ->
+            callback.invoke(value)
+            null
         }
     }
 

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMMessenger.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMMessenger.kt
@@ -97,7 +97,7 @@ class ITMMessenger(private val itmApplication: ITMApplication) {
         fun handleMessage(queryId: Int, type: String, data: JsonValue?) {
             itmMessenger.logQuery("Request JS -> Kotlin", queryId, type, data)
             callback.invoke(data, { result ->
-                itmMessenger.handleMessageSuccess(queryId, type, result ?: Json.NULL)
+                itmMessenger.handleMessageSuccess(queryId, type, result)
             }, { error ->
                 itmMessenger.handleMessageFailure(queryId, type, error)
             })
@@ -262,11 +262,11 @@ class ITMMessenger(private val itmApplication: ITMApplication) {
      * @param type The type of the message.
      * @param result The arbitrary result to send back to the web view.
      */
-    private fun handleMessageSuccess(queryId: Int, type: String, result: JsonValue) {
+    private fun handleMessageSuccess(queryId: Int, type: String, result: JsonValue?) {
         logQuery("Response Kotlin -> JS", queryId, type, result)
         mainScope.launch {
             val message = JsonObject()
-            if (!result.isNull)
+            if (result != null)
                 message["response"] = result
             val jsonString = message.toString()
             val dataString = Base64.encodeToString(jsonString.toByteArray(), Base64.NO_WRAP)

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMMessenger.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMMessenger.kt
@@ -10,6 +10,7 @@ import android.util.Base64
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import com.eclipsesource.json.Json
+import com.eclipsesource.json.JsonObject
 import com.eclipsesource.json.JsonValue
 import com.github.itwin.mobilesdk.jsonvalue.toPrettyString
 import java.util.concurrent.atomic.AtomicInteger
@@ -17,9 +18,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 
-typealias ITMQueryCallback = (JsonValue?, success: ((JsonValue?) -> Unit)?, failure: ((Exception) -> Unit)?) -> Unit
 typealias ITMSuccessCallback = (JsonValue?) -> Unit
 typealias ITMFailureCallback = (Exception) -> Unit
+typealias ITMQueryCallback = (JsonValue?, success: ITMSuccessCallback?, failure: ITMFailureCallback?) -> Unit
 
 /**
  * Class for sending and receiving messages to and from a [WebView][android.webkit.WebView] using the
@@ -96,9 +97,7 @@ class ITMMessenger(private val itmApplication: ITMApplication) {
         fun handleMessage(queryId: Int, type: String, data: JsonValue?) {
             itmMessenger.logQuery("Request JS -> Kotlin", queryId, type, data)
             callback.invoke(data, { result ->
-                if (result != null) {
-                    itmMessenger.handleMessageSuccess(queryId, type, result)
-                }
+                itmMessenger.handleMessageSuccess(queryId, type, result ?: Json.NULL)
             }, { error ->
                 itmMessenger.handleMessageFailure(queryId, type, error)
             })
@@ -266,8 +265,9 @@ class ITMMessenger(private val itmApplication: ITMApplication) {
     private fun handleMessageSuccess(queryId: Int, type: String, result: JsonValue) {
         logQuery("Response Kotlin -> JS", queryId, type, result)
         mainScope.launch {
-            val message = Json.`object`()
-            message["response"] = result
+            val message = JsonObject()
+            if (!result.isNull)
+                message["response"] = result
             val jsonString = message.toString()
             val dataString = Base64.encodeToString(jsonString.toByteArray(), Base64.NO_WRAP)
             webView?.evaluateJavascript("$queryResponseName$queryId('$dataString')", null)
@@ -302,8 +302,8 @@ class ITMMessenger(private val itmApplication: ITMApplication) {
     private fun handleMessageFailure(queryId: Int, type: String, error: Exception) {
         logQuery("Error Response Kotlin -> JS", queryId, type, null)
         mainScope.launch {
-            val message = Json.`object`()
-            message["error"] = error.message
+            val message = JsonObject()
+            message["error"] = if (error.message != null) Json.value(error.message) else JsonObject()
             val jsonString = message.toString()
             val dataString = Base64.encodeToString(jsonString.toByteArray(), Base64.NO_WRAP)
             webView?.evaluateJavascript("$queryResponseName$queryId('$dataString')", null)
@@ -386,20 +386,6 @@ class ITMMessenger(private val itmApplication: ITMApplication) {
             val dataString = Base64.encodeToString(data.toString().toByteArray(), Base64.NO_WRAP)
             pendingQueries[queryId] = Triple(type, success, failure)
             webView?.evaluateJavascript("$queryName('$type', $queryId, '$dataString')", null)
-        }
-    }
-
-    /**
-     * Add a handler for queries from the web view that do not include a response.
-     *
-     * @param type Query type.
-     * @param callback Function called when a message is received.
-     *
-     * @return The [ITMMessenger.ITMHandler] value to subsequently pass into [removeHandler]
-     */
-    fun registerMessageHandler(type: String, callback: ITMSuccessCallback): ITMHandler {
-        return registerQueryHandler(type) { value, _, _ ->
-            callback.invoke(value)
         }
     }
 


### PR DESCRIPTION
ITMMessenger updates
- Ensure handleMessage always calls handleMessageSuccess or handleMessageFailure
- handleMessageSuccess now handles null values
- handleMessageFailure now is consistent with iOS for exceptions with null messages
- removed registerMessageHandler as it's not needed

ITMCoMessenger
- Changed registerMessageHandler to call its own registeryQueryHandler so that errors are properly handled.

ITMApplication: updated preferred color scheme message handling
- Changed registerMessageHandler call to registerQueryHandler since the former was removed
- Removed MainScope().launch wrapper as it's no longer needed