### PR TITLE
Code cleanup for ITMApplication

### DIFF
--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
@@ -19,6 +19,7 @@ import android.view.ViewGroup
 import android.view.WindowInsets
 import android.webkit.*
 import androidx.activity.ComponentActivity
+import androidx.annotation.CallSuper
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -31,9 +32,10 @@ import com.github.itwin.mobilesdk.jsonvalue.optStringOrNull
 import com.github.itwin.mobilesdk.jsonvalue.toMap
 import kotlinx.coroutines.*
 import org.json.JSONObject
-import java.lang.Integer.max
+import java.lang.Float.max
 import java.net.URLEncoder
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.properties.Delegates
 
 private enum class ReachabilityStatus {
     NotReachable,
@@ -47,19 +49,19 @@ private enum class ReachabilityStatus {
  * @property name The name of the hash parameter.
  * @property value The value of the hash parameter.
  */
-class HashParam(val name: String, val value: String?) {
+class HashParam(val name: String, val value: String) {
     companion object {
         /**
          * Create a string hash param from a value in configData.
          * @param configData The source of the config data for the [HashParam].
          * @param configKey The key to use to look up the value in [configData].
          * @param name The name of the [HashParam]
-         * @return A [HashParam] with the string value contained in the given value in [configData], or null
-         * if [configData] is null or the value does not exist.
+         * @return A [HashParam] with the string value contained in the given value in [configData],
+         * or null if [configData] is null or the value does not exist.
          */
         fun fromConfigData(configData: JSONObject?, configKey: String, name: String) =
-            configData?.optStringOrNull(configKey)?.let { value ->
-                HashParam(name, value)
+            configData?.optStringOrNull(configKey)?.let {
+                HashParam(name, it)
             }
     }
 
@@ -76,27 +78,30 @@ class HashParam(val name: String, val value: String?) {
 typealias HashParams = List<HashParam>
 
 /**
- * Convert the array of HashParam values into a string suitable for use in a URL.
+ * Convert the list of HashParam values into a string suitable for use in a URL.
  */
 fun HashParams.toUrlString(): String {
     if (this.isEmpty()) {
         return ""
     }
-    return "&" + this.joinToString("&") { hashParam ->
-        "${hashParam.name}=${URLEncoder.encode(hashParam.value, "utf-8")}"
+    return "&" + this.joinToString("&") {
+        "${it.name}=${URLEncoder.encode(it.value, "utf-8")}"
     }
 }
 
 /**
  * Main class for interacting with an iTwin Mobile SDK-based web app.
  *
- * __Note:__ Most applications will override this class in order to customize the behavior and register for messages.
+ * > __Note:__ Most applications will override this class in order to customize the behavior and
+ * register for messages.
  *
  * @param appContext The Android Application object's `Context`.
  * @param attachWebViewLogger Whether or not to attach an [ITMWebViewLogger] to the application's
  * webView, default is `false`.
- * @param forceExtractBackendAssets Whether or not to always extract backend assets from during
- * application launch, default is `false`. Only set this to `true` for debug builds.
+ * @param forceExtractBackendAssets Whether or not to always extract backend assets during
+ * application launch, default is `false`. Set this to `true` for debug builds where the backend
+ * assets might change without a version number change, since backend assets are normally only
+ * extracted after a fresh install or when the app's version number changes.
  */
 open class ITMApplication(
     val appContext: Context,
@@ -104,7 +109,7 @@ open class ITMApplication(
     private val forceExtractBackendAssets: Boolean = false) {
 
     /**
-     * The `MobileUi.preferredColorScheme` value set by the TypeScript code.
+     * Enum for the `MobileUi.preferredColorScheme` value set by the TypeScript code.
      */
     enum class PreferredColorScheme(val value: Long) {
         Automatic(0),
@@ -130,8 +135,8 @@ open class ITMApplication(
          */
         fun toNightMode() = when (this) {
             Automatic -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-            Light -> AppCompatDelegate.MODE_NIGHT_NO
-            Dark -> AppCompatDelegate.MODE_NIGHT_YES
+            Light     -> AppCompatDelegate.MODE_NIGHT_NO
+            Dark      -> AppCompatDelegate.MODE_NIGHT_YES
         }
     }
 
@@ -160,7 +165,8 @@ open class ITMApplication(
     val isBackendInitialized: Boolean get() = _isBackendInitialized.get()
 
     /**
-     * The `MobileUi.preferredColorScheme` value set by the TypeScript code, default is automatic.
+     * The `MobileUi.preferredColorScheme` value set by the TypeScript code, default is
+     * [Automatic][PreferredColorScheme.Automatic].
      */
     var preferredColorScheme = PreferredColorScheme.Automatic
 
@@ -185,10 +191,21 @@ open class ITMApplication(
     var frontendBaseUrl = ""
 
     /**
-     * The [ITMMessenger] for communication between native code and JavaScript code (and vice versa).
+     * The [ITMLogger] responsible for handling log messages (both from native code and JavaScript
+     * code). The default logger uses [Log][android.util.Log] for the messages. Replace this object
+     * with an [ITMLogger] subclass to change the logging behavior.
+     *
+     * > __Note:__ Updating this value also updates the logger being used by [messenger].
      */
-    @Suppress("LeakingThis")
-    var messenger = ITMMessenger(this)
+    var logger: ITMLogger by Delegates.observable(ITMLogger()) { _, _, new ->
+        messenger.logger = new
+    }
+
+    /**
+     * The [ITMMessenger] for communication between native code and JavaScript code (and vice
+     * versa).
+     */
+    var messenger = ITMMessenger(logger)
 
     /**
      * The [ITMCoMessenger] associated with [messenger].
@@ -196,14 +213,9 @@ open class ITMApplication(
     var coMessenger = ITMCoMessenger(messenger)
 
     /**
-     * The [ITMLogger] responsible for handling log messages (both from native code and JavaScript code). The default logger
-     * uses [Log][android.util.Log] for the messages. Replace this object with an [ITMLogger] subclass to change the logging behavior.
-     */
-    var logger = ITMLogger()
-
-    /**
-     * The [ITMGeolocationManager] that handles Geolocation messages from the `navigator.geolocation` Polyfill in
-     * `@itwin/mobile-sdk-core`. This value is initialized in [setupWebView].
+     * The [ITMGeolocationManager] that handles Geolocation messages from the
+     * `navigator.geolocation` Polyfill in `@itwin/mobile-sdk-core`. This value is initialized in
+     * [setupWebView].
      */
     var geolocationManager: ITMGeolocationManager? = null
 
@@ -222,21 +234,24 @@ open class ITMApplication(
     val assetLoader = ITMWebAssetLoader(appContext)
 
     /**
-     * Kotlin Coroutine that waits for frontend initialization to complete, if it has not already completed.
+     * Kotlin Coroutine that waits for frontend initialization to complete, if it has not already
+     * completed.
      */
     suspend fun waitForFrontendInitialize() {
         frontendInitTask.join()
     }
 
     /**
-     * Kotlin Coroutine that waits for backend initialization to complete, if it has not already completed.
+     * Kotlin Coroutine that waits for backend initialization to complete, if it has not already
+     * completed.
      */
     suspend fun waitForBackendInitialize() {
         backendInitTask.join()
     }
 
     /**
-     * Finish initialization, calling functions that can't go into the constructor because they are open.
+     * Finish initialization, calling functions that can't go into the constructor because they are
+     * open.
      */
     open fun finishInit() {
         configData = loadITMAppConfig()
@@ -249,10 +264,11 @@ open class ITMApplication(
                 ITMMessenger.isFullLoggingEnabled = true
             }
 
-            // Add the configuration vars to the environment so they can be picked up by other code (i.e. the typescript backend)
-            configData.toMap().forEach { entry ->
-                if (entry.key.startsWith("ITMAPPLICATION_")) {
-                    Os.setenv(entry.key, entry.value as String, true)
+            // Add the configuration vars with an "ITMAPPLICATION_" prefix to the environment so
+            // they can be picked up by other code (i.e. the typescript backend)
+            configData.toMap().forEach {
+                if (it.key.startsWith("ITMAPPLICATION_")) {
+                    Os.setenv(it.key, it.value as String, true)
                 }
             }
         }
@@ -265,29 +281,36 @@ open class ITMApplication(
      *
      * The following keys in the returned value are used by iTwin Mobile SDK:
      *
-     *     | Key                                 | Description                                                                                           |
-     *     |-------------------------------------|-------------------------------------------------------------------------------------------------------|
-     *     | ITMAPPLICATION_CLIENT_ID            | ITMOIDCAuthorizationClient required value containing the app's client ID.                                 |
-     *     | ITMAPPLICATION_SCOPE                | ITMOIDCAuthorizationClient required value containing the app's scope.                                     |
-     *     | ITMAPPLICATION_ISSUER_UR            | ITMOIDCAuthorizationClient optional value containing the app's issuer URL.                                |
-     *     | ITMAPPLICATION_REDIRECT_URI         | ITMOIDCAuthorizationClient optional value containing the app's redirect URL.                              |
-     *     | ITMAPPLICATION_MESSAGE_LOGGING      | Set to YES to have ITMMessenger log message traffic between JavaScript and Swift.                     |
-     *     | ITMAPPLICATION_FULL_MESSAGE_LOGGING | Set to YES to include full message data in the ITMMessenger message logs. (DO NOT USE IN PRODUCTION.) |
+     *     | Key                                 | Description                                                 |
+     *     |-------------------------------------|-------------------------------------------------------------|
+     *     | ITMAPPLICATION_CLIENT_ID            | ITMOIDCAuthorizationClient required value containing the    |
+     *     |                                     | app client ID.                                              |
+     *     | ITMAPPLICATION_SCOPE                | ITMOIDCAuthorizationClient required value containing the    |
+     *     |                                     | app scope.                                                  |
+     *     | ITMAPPLICATION_ISSUER_UR            | ITMOIDCAuthorizationClient optional value containing the    |
+     *     |                                     | app issuer URL.                                             |
+     *     | ITMAPPLICATION_REDIRECT_URI         | ITMOIDCAuthorizationClient optional value containing the    |
+     *     |                                     | app redirect URL.                                           |
+     *     | ITMAPPLICATION_MESSAGE_LOGGING      | Set to YES to have ITMMessenger log message traffic between |
+     *     |                                     | JavaScript and Swift.                                       |
+     *     | ITMAPPLICATION_FULL_MESSAGE_LOGGING | Set to YES to include full message data in the ITMMessenger |
+     *     |                                     | message logs. (DO NOT USE IN PRODUCTION.)                   |
      *
-     * Note: Other keys may be present but are ignored by iTwin Mobile SDK. For example, the iTwin Mobile SDK sample apps include keys with an `ITMSAMPLE_` prefix.
+     * Note: Other keys may be present but are ignored by iTwin Mobile SDK. For example, the iTwin
+     * Mobile SDK sample apps include keys with an `ITMSAMPLE_` prefix.
      *
-     * @return The parsed contents of `ITMApplication/ITMAppConfig.json`, or null if the file does not
-     * exist, or there is an error parsing the file.
+     * @return The parsed contents of `ITMApplication/ITMAppConfig.json`, or null if the file does
+     * not exist, or there is an error parsing the file.
      */
     open fun loadITMAppConfig() = try {
-        val manager = appContext.assets
-        JSONObject(manager.open("ITMApplication/ITMAppConfig.json").bufferedReader().use { it.readText() })
+        JSONObject(appContext.assets.open("ITMApplication/ITMAppConfig.json").bufferedReader().use { it.readText() })
     } catch (ex: Exception) {
         null
     }
 
     /**
-     * Initialize the iTwinJS backend if it is not initialized yet. This can be called from the launch activity.
+     * Initialize the iTwinJS backend if it is not initialized yet. This can be called from the
+     * launch activity.
      *
      * @param allowInspectBackend Allow inspection of the backend code, default false.
      */
@@ -311,7 +334,8 @@ open class ITMApplication(
     }
 
     /**
-     * Finish initialization of the frontend including creating the nativeUI and completing the frontendInitTask.
+     * Finish initialization of the frontend including creating the nativeUI and completing the
+     * frontendInitTask.
      *
      * @param context The [Context] to use to create the native UI.
      */
@@ -321,25 +345,47 @@ open class ITMApplication(
     }
 
     /**
-     * Associates with the given activity and then initializes the frontend.
+     * Associate with the given activity and then initialize the frontend.
+     *
+     * If you have not already called [initializeBackend], this will call it.
      *
      * @param activity The activity to associate with and context to use during initialization.
-     * @param allowInspectBackend Allow inspection of the backend code, default false.
+     * @param allowInspectBackend Allow inspection of the backend code, default false. Do not set
+     * this to `true` in production builds.
      */
     open fun initializeFrontend(activity: ComponentActivity, allowInspectBackend: Boolean = false) {
         associateWithActivity(activity)
         initializeFrontend(activity as Context, allowInspectBackend)
     }
 
+    private val connectivityManager
+        get() = appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val connectivityCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            super.onAvailable(network)
+            updateAvailability(true)
+        }
+
+        override fun onLost(network: Network) {
+            super.onLost(network)
+            updateAvailability(false)
+        }
+    }
+
     /**
      * Initialize the iTwinJS frontend if it is not initialized yet.
      *
      * This requires the Looper to be running, so cannot be called from the launch activity.
+     *
      * If you have not already called [initializeBackend], this will call it.
      *
      * @param context The [Context].
-     * @param allowInspectBackend Allow inspection of the backend code, default false.
-     * @param existingWebView An existing webview to use instead of creating one.
+     * @param allowInspectBackend Allow inspection of the backend code, default false. Do not set
+     * this to `true` in production builds.
+     * @param existingWebView An existing webview to use instead of creating one. If you pass a
+     * value here, you need to manually call
+     * [onConfigurationChanged][ITMNativeUI.onConfigurationChanged] on [nativeUI].
      */
     open fun initializeFrontend(context: Context, allowInspectBackend: Boolean = false, existingWebView: WebView? = null) {
         // Note: geolocationManager needs to be created *before* the activity has started
@@ -357,6 +403,7 @@ open class ITMApplication(
                 return@launch
             }
             try {
+                // Wait for backend to finish initializing.
                 backendInitTask.join()
                 webView = existingWebView ?: object : WebView(context) {
                     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -391,18 +438,7 @@ open class ITMApplication(
                     it.webView = webView
                     it.loadEntryPoint(baseUrl, getUrlHashParams().toUrlString())
                 }
-                val connectivityManager = appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-                connectivityManager.registerDefaultNetworkCallback(object : ConnectivityManager.NetworkCallback() {
-                    override fun onAvailable(network: Network) {
-                        super.onAvailable(network)
-                        updateAvailability(true)
-                    }
-
-                    override fun onLost(network: Network) {
-                        super.onLost(network)
-                        updateAvailability(false)
-                    }
-                })
+                connectivityManager.registerDefaultNetworkCallback(connectivityCallback)
                 if (usingRemoteServer) {
                     MainScope().launch {
                         delay(10000)
@@ -464,23 +500,27 @@ open class ITMApplication(
      * Function that creates an [ITMNativeUI] object for this [ITMApplication]. Override to return a
      * custom [ITMNativeUI] subclass.
      */
+    @CallSuper
     open fun createNativeUI(context: Context) =
         webView?.let {
-            ITMNativeUI(context, it, coMessenger)
+            ITMNativeUI(context, it, coMessenger).apply { registerStandardComponents() }
         }
 
     /**
      * Clean up any existing frontend and initialize the frontend again.
      *
-     * __Note:__ Call this if the [WebView] runs out of memory, killing the web app.
+     * > __Note:__ Call this if the [WebView] runs out of memory, killing the web app.
      *
      * @param context The [Context].
      */
     open fun reinitializeFrontend(context: Context) {
+        webViewLogger?.detach()
+        webViewLogger = null
         webView = null
-        messenger = ITMMessenger(this)
+        messenger = ITMMessenger(logger)
         coMessenger = ITMCoMessenger(messenger)
         isLoaded.value = false
+        connectivityManager.unregisterNetworkCallback(connectivityCallback)
         initializeFrontend(context)
     }
 
@@ -488,7 +528,6 @@ open class ITMApplication(
         available?.let {
             reachabilityStatus = ReachabilityStatus.NotReachable
             if (it) {
-                val connectivityManager = appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
                 reachabilityStatus = if (connectivityManager.isActiveNetworkMetered) ReachabilityStatus.ReachableViaWWAN else ReachabilityStatus.ReachableViaWiFi
             }
         }
@@ -503,16 +542,22 @@ open class ITMApplication(
         frontendInitTask.cancel()
         frontendInitTask = Job()
         _isBackendInitialized.set(false)
+        webViewLogger?.detach()
+        webViewLogger = null
         webView = null
-        messenger = ITMMessenger(this)
+        messenger = ITMMessenger(logger)
         coMessenger = ITMCoMessenger(messenger)
+        connectivityManager.unregisterNetworkCallback(connectivityCallback)
     }
 
     /**
-     * Function that creates an [ITMMessenger] object for this [ITMApplication]. Override to return a
-     * custom [ITMMessenger] subclass.
+     * Function that creates an [ITMMessenger] object for this [ITMApplication]. Override to return
+     * a custom [ITMMessenger] subclass.
+     *
+     * > __Note:__ The value returned from here will have its [logger][ITMMessenger.logger] updated
+     * any time this [ITMApplication]'s [logger] is updated.
      */
-    open fun createMessenger() = ITMMessenger(this)
+    open fun createMessenger() = ITMMessenger(logger)
 
     /**
      * Update the application to conform to the [preferredColorScheme].
@@ -524,16 +569,15 @@ open class ITMApplication(
     /**
      * Set up [webView] for usage with iTwin Mobile SDK.
      */
-    @Suppress("LeakingThis")
     protected open fun setupWebView() {
         val webView = this.webView ?: return
         messenger.webView = webView
         if (attachWebViewLogger) {
             webViewLogger = ITMWebViewLogger(webView, ::onWebViewLog)
         }
-        messenger.registerQueryHandler<Map<String, Number>, Unit>("Bentley_ITM_updatePreferredColorScheme") { value, _, _ ->
-            value.getOptionalLong("preferredColorScheme")?.let { longValue ->
-                preferredColorScheme = PreferredColorScheme.fromLong(longValue) ?: PreferredColorScheme.Automatic
+        coMessenger.registerQueryHandler<Map<String, Number>, Unit>("Bentley_ITM_updatePreferredColorScheme") { params ->
+            params.getOptionalLong("preferredColorScheme")?.let {
+                preferredColorScheme = PreferredColorScheme.fromLong(it) ?: PreferredColorScheme.Automatic
                 applyPreferredColorScheme()
             }
         }
@@ -558,22 +602,23 @@ open class ITMApplication(
             }
 
             override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
-                val result = this@ITMApplication.shouldInterceptRequest(view, request)
-                return result ?: super.shouldInterceptRequest(view, request)
+                return this@ITMApplication.shouldInterceptRequest(view, request) ?: super.shouldInterceptRequest(view, request)
             }
 
             override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-                if (this@ITMApplication.shouldOverrideUrlLoading(view, request)) {
-                    return true
+                return if (this@ITMApplication.shouldOverrideUrlLoading(view, request)) {
+                    true
+                } else {
+                    super.shouldOverrideUrlLoading(view, request)
                 }
-                return super.shouldOverrideUrlLoading(view, request)
             }
 
             override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
-                if (this@ITMApplication.onRenderProcessGone(view, detail)) {
-                    return true
+                return if (this@ITMApplication.onRenderProcessGone(view, detail)) {
+                    true
+                } else {
+                    super.onRenderProcessGone(view, detail)
                 }
-                return super.onRenderProcessGone(view, detail)
             }
 
             override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
@@ -601,20 +646,11 @@ open class ITMApplication(
         }
     }
 
-    private data class Quint<out A, out B, out C, out D, out E>(
-        val first: A,
-        val second: B,
-        val third: C,
-        val fourth: D,
-        val fifth: E
-    ) {
-        /**
-         * Returns string representation of the [Quint] including its [first], [second], [third], [fourth], and [fifth] values.
-         */
-        override fun toString(): String = "($first, $second, $third, $fourth, $fifth)"
+    private data class SafeAreaValues(val left: Float, val right: Float, val top: Float, val bottom: Float) {
+        val sides by lazy { max(left, right) }
     }
 
-    private fun getSafeAreas(activity: Activity, view: View, insets: WindowInsets): Quint<Float, Float, Float, Float, Float> {
+    private fun getSafeAreas(activity: Activity, view: View, insets: WindowInsets): SafeAreaValues {
         fun toDp(value: Int): Float {
             val density = activity.resources.displayMetrics.density
             return value / density
@@ -625,49 +661,45 @@ open class ITMApplication(
             insetsType = insetsType or WindowInsetsCompat.Type.systemBars()
 
         return with(WindowInsetsCompat.toWindowInsetsCompat(insets, view).getInsets(insetsType)) {
-            Quint(toDp(max(left, right)), toDp(left), toDp(right), toDp(top), toDp(bottom))
+            SafeAreaValues(toDp(left), toDp(right), toDp(top), toDp(bottom))
         }
     }
 
-    @Suppress("DestructuringDeclarationWithTooManyEntries")
     private fun updateSafeAreas(view: View, insets: WindowInsets) {
         val activity = ((view.parent as? ViewGroup)?.context as? Activity) ?: return
-        val (sides, left, right, top, bottom) = getSafeAreas(activity, view, insets)
-        val message = mapOf(
-            // We want both sides to have the same safe area.
-            "left" to sides,
-            "right" to sides,
-            // Include the actual left/right insets so developers can use them if desired.
-            "minLeft" to left,
-            "minRight" to right,
-            "top" to top,
-            "bottom" to bottom,
-        )
-        messenger.send("Bentley_ITM_muiUpdateSafeAreas", message)
+        with(getSafeAreas(activity, view, insets)) {
+            val message = mapOf(
+                // We want both sides to have the same safe area.
+                "left" to sides,
+                "right" to sides,
+                // Include the actual left/right insets so developers can use them if desired.
+                "minLeft" to left,
+                "minRight" to right,
+                "top" to top,
+                "bottom" to bottom,
+            )
+            messenger.send("Bentley_ITM_muiUpdateSafeAreas", message)
+        }
     }
 
     /**
      * Called when the [webView]'s [WebViewClient] calls [WebViewClient.onPageFinished].
-     *
-     * Make sure to call super if you override this function.
      */
+    @CallSuper
     open fun onPageFinished(view: WebView, url: String) {
         webViewLogger?.inject()
     }
 
     /**
      * Called when the [webView]'s [WebViewClient] calls [WebViewClient.onPageStarted].
-     *
-     * Make sure to call super if you override this function.
      */
+    @CallSuper
     open fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
         updateAvailability()
     }
 
     /**
      * Called when the [webView]'s [WebViewClient] calls [WebViewClient.shouldInterceptRequest].
-     *
-     * This default implementation simply returns null.
      */
     open fun shouldInterceptRequest(view: WebView, request: WebResourceRequest) =
         assetLoader.shouldInterceptRequest(request.url)
@@ -690,6 +722,8 @@ open class ITMApplication(
      * Called when the [webView]'s [WebViewClient] calls [WebViewClient.onReceivedError].
      *
      * This default implementation simply returns false.
+     *
+     * @return `true` to prevent the [WebViewClient] from calling `super.onReceivedError`.
      */
     open fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) = false
 
@@ -703,15 +737,15 @@ open class ITMApplication(
     /**
      * Get the relative path used as the home path for the backend.
      *
-     * @return The relative path to where the backend home should go. The default implementation returns
-     * `"ITMApplication/home"`.
+     * @return The relative path to where the backend home should go. The default implementation
+     * returns `"ITMApplication/home"`.
      */
     open fun getBackendHomePath() = "ITMApplication/home"
 
     /**
      * Get the relative path used where the backend is stored in the app assets.
      *
-     * @return The relative path to where the backend home should go. The default implementation returns
+     * @return The relative path to where the backend should go. The default implementation returns
      * `"ITMApplication/backend"`.
      */
     open fun getBackendPath() = "ITMApplication/backend"
@@ -719,23 +753,24 @@ open class ITMApplication(
     /**
      * Get name of the entry point JavaScript file for the backend.
      *
-     * @return The relative path to where the backend home should go. The default implementation returns
-     * `"main.js"`.
+     * @return The name of the entry point JavaScript file for the backend. The default
+     * implementation returns `"main.js"`.
      */
     open fun getBackendEntryPointScript() = "main.js"
 
     /**
      * Get the base URL for the frontend.
      *
-     * @return The URL to use for the frontend. The default uses the `ITMAPPLICATION_BASE_URL` value from [configData],
-     * if present, or `"https://appassets.itwinjs.org/assets/ITMApplication/frontend/index.html` otherwise.
+     * @return The URL to use for the frontend. The default uses the `ITMAPPLICATION_BASE_URL` value
+     * from [configData], if present, or
+     * `"https://appassets.itwinjs.org/assets/ITMApplication/frontend/index.html"` otherwise.
      *
-     * __Note:__ The default URL is designed to work with [ITMWebAssetLoader].
+     * > __Note:__ The default URL is designed to work with [ITMWebAssetLoader].
      */
     open fun getBaseUrl(): String {
-        configData?.optStringOrNull("ITMAPPLICATION_BASE_URL")?.let { baseUrl ->
+        configData?.optStringOrNull("ITMAPPLICATION_BASE_URL")?.let {
             usingRemoteServer = true
-            return baseUrl
+            return it
         }
         usingRemoteServer = false
         return "${ITMWebAssetLoader.URL_PREFIX}ITMApplication/frontend/index.html"
@@ -744,10 +779,12 @@ open class ITMApplication(
     /**
      * Generates the list of [HashParam] values to be used in the web app's URL. Override to add
      * custom hash parameters to the URL used to open the frontend. If you override this function,
-     * you must include the results from super.
+     * you must include the results from super in your list.
+     *
      * @return The default [ITMApplication] [HashParam] values based on the contents of
      * [configData].
      */
+    @CallSuper
     open suspend fun getUrlHashParams(): HashParams =
         listOfNotNull(
             HashParam.fromConfigData(configData, "ITMAPPLICATION_API_PREFIX", "apiPrefix")
@@ -758,17 +795,19 @@ open class ITMApplication(
      *
      * Override this function in a subclass in order to add custom behavior.
      *
-     * If your application handles authorization on its own, create a subclass of [AuthorizationClient].
+     * If your application handles authorization on its own, create a subclass of
+     * [AuthorizationClient].
      *
-     * @return An instance of [AuthorizationClient], or null if you don't want any authentication in your app.
+     * @return An instance of [AuthorizationClient], or `null` if you don't want any authentication
+     * in your app.
      */
     open fun createAuthorizationClient(): AuthorizationClient? =
-        configData?.let { configData ->
-            ITMOIDCAuthorizationClient(this, configData)
+        configData?.let {
+            ITMOIDCAuthorizationClient(this, it)
         }
 
     /**
-     * If the [authorizationClient] is null, first sets it using [createAuthorizationClient].
+     * If the [authorizationClient] is `null`, first sets it using [createAuthorizationClient].
      *
      * Override this function in a subclass in order to add custom behavior.
      *
@@ -780,12 +819,15 @@ open class ITMApplication(
     /**
      * Creates the [ITMGeolocationManager] to be used for this iTwin Mobile web app.
      *
-     * @return An instance of [ITMGeolocationManager] or null if your app doesn't need geolocation.
+     * Override this function in a subclass in order to add custom behavior.
+     *
+     * @return An instance of [ITMGeolocationManager] or `null` if your app doesn't need
+     * geolocation.
      */
     open fun createGeolocationManager(): ITMGeolocationManager? = ITMGeolocationManager(appContext)
 
     /**
-     * If the [geolocationManager] is null, first sets it using [createGeolocationManager].
+     * If the [geolocationManager] is `null`, first sets it using [createGeolocationManager].
      *
      * Override this function in a subclass in order to add custom behavior.
      *

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMApplication.kt
@@ -606,19 +606,11 @@ open class ITMApplication(
             }
 
             override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-                return if (this@ITMApplication.shouldOverrideUrlLoading(view, request)) {
-                    true
-                } else {
-                    super.shouldOverrideUrlLoading(view, request)
-                }
+                return this@ITMApplication.shouldOverrideUrlLoading(view, request) || super.shouldOverrideUrlLoading(view, request)
             }
 
             override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
-                return if (this@ITMApplication.onRenderProcessGone(view, detail)) {
-                    true
-                } else {
-                    super.onRenderProcessGone(view, detail)
-                }
+                return this@ITMApplication.onRenderProcessGone(view, detail) || super.onRenderProcessGone(view, detail)
             }
 
             override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMMessenger.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMMessenger.kt
@@ -26,20 +26,13 @@ typealias ITMQueryCallback<I, O> = (I, success: ITMSuccessCallback<O>?, failure:
  * Class for sending and receiving messages to and from a [WebView][android.webkit.WebView] using
  * the `Messenger` class in `@itwin/mobile-sdk-core`.
  *
- * @param itmApplication The [ITMApplication] that will be sending and receiving messages. If this
- * is `null`, you must set [logger] to an [ITMLogger] instance if you want any logging.
+ * @property logger The [ITMLogger] to use for logging. If this is `null`, no logging happens.
  */
-class ITMMessenger(private val itmApplication: ITMApplication? = null) {
+class ITMMessenger(var logger: ITMLogger? = null) {
     /**
      * Empty interface used for message handlers.
      */
     interface ITMHandler
-
-    /**
-     * The [ITMLogger] to use for logging if [itmApplication] is null.
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
-    var logger: ITMLogger? = null
 
     /**
      * The [WebView][android.webkit.WebView] with which this [ITMMessenger] communicates.
@@ -366,29 +359,21 @@ class ITMMessenger(private val itmApplication: ITMApplication? = null) {
     }
 
     /**
-     * The active logger. If [itmApplication] is non-null, use the logger from that, otherwise
-     * [logger].
-     */
-    private val activeLogger: ITMLogger? = itmApplication?.logger ?: logger
-
-    /**
-     * Log an error message using [itmApplication.logger][ITMApplication.logger], or [logger] if
-     * that is `null`. If both are `null`, nothing is logged.
+     * Log an error message using [logger]. If [logger] is `null`, nothing is logged.
      *
      * @param message Error message to log.
      */
     private fun logError(message: String) {
-        activeLogger?.log(ITMLogger.Severity.Error, message)
+        logger?.log(ITMLogger.Severity.Error, message)
     }
 
     /**
-     * Log an info message using [itmApplication.logger][ITMApplication.logger], or [logger] if
-     * that is `null`. If both are `null`, nothing is logged.
+     * Log an info message using [logger]. If [logger] is `null`, nothing is logged.
      *
      * @param message Info message to log.
      */
     private fun logInfo(message: String) {
-        activeLogger?.log(ITMLogger.Severity.Info, message)
+        logger?.log(ITMLogger.Severity.Info, message)
     }
 
     /**

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMNativeUI.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMNativeUI.kt
@@ -61,12 +61,16 @@ open class ITMNativeUI(
     val context: Context,
     val webView: WebView,
     val coMessenger: ITMCoMessenger) {
-    @Suppress("MemberVisibilityCanBePrivate") val components: MutableList<ITMNativeUIComponent> = mutableListOf()
+    @Suppress("MemberVisibilityCanBePrivate")
+    val components: MutableList<ITMNativeUIComponent> = mutableListOf()
 
-    init {
-        @Suppress("LeakingThis")
+    /**
+     * Register the standard [ITMNativeUIComponent] subclasses that are part of mobile-sdk-android.
+     *
+     * This is called automatically by [ITMApplication.createNativeUI].
+     */
+    fun registerStandardComponents() {
         components.add(ITMActionSheet(this))
-        @Suppress("LeakingThis")
         components.add(ITMAlert(this))
     }
 

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMWebViewLogger.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMWebViewLogger.kt
@@ -89,7 +89,6 @@ open class ITMWebViewLogger(
     /**
      * Detach from [webView].
      */
-    @Suppress("unused")
     fun detach() {
         webView.removeJavascriptInterface(JS_INTERFACE_NAME)
     }


### PR DESCRIPTION
Also contains updates to other classes that are a direct result of `ITMApplication` changes.

Notes:

1. The `ITMMessenger` changes were done to avoid potential issues that previously required the suppression of `LeakingThis`. Changing `logger` to `observable` and updating the messenger when the logger changes maintains the old functionality.
2. The `ITMNativeUI` changes were also done to avoid having to suppress `LeakingThis`, and to avoid running into problems due to that suppression.
3. The `ITMWebViewLogger` change was due to fixes added to `ITMApplication` to detach the logger when appropriate.