### PR TITLE
Update Gradle groupId to `com.github.itwin.mobilesdk`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,4 +63,4 @@ echo sdk.dir=/Users/$USER/Libarary/Android/sdk > local.properties
 To use the locally published Mobile SDK in your App do the following:
 - Add `mavenLocal()` to the list of repositories in the `settings.gradle` file. Make sure it is before any other repositories. Look at `mobile-sdk-android/settings.gradle` to see an example.
 - In your app's `build.gradle` file, add a dependency to `mobile-sdk-android`. Something like this should work:
-`implementation 'com.github.itwin:mobile-sdk-android:0.9.12'`
+`implementation 'com.github.itwin.mobilesdk:mobile-sdk-android:0.22.3'`

--- a/mobile-sdk/build.gradle
+++ b/mobile-sdk/build.gradle
@@ -88,7 +88,7 @@ afterEvaluate {
             // Creates a Maven publication called 'release'.
             release(MavenPublication) {
                 from components.release
-                groupId = 'com.github.itwin'
+                groupId = 'com.github.itwin.mobilesdk'
                 artifactId = 'mobile-sdk-android'
                 version = '0.22.3'
             }
@@ -96,7 +96,7 @@ afterEvaluate {
             debug(MavenPublication) {
                 from components.debug
                 artifact(sourceJar)
-                groupId = 'com.github.itwin'
+                groupId = 'com.github.itwin.mobilesdk'
                 artifactId = 'mobile-sdk-android'
                 version = '0.22.3-debug'
             }


### PR DESCRIPTION
The old value of `com.github.itwin` was interfering with direct access to the mobile add-on.