### PR TITLE
Ignore unreliable and low-accuracy compass readings.

### DIFF
--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
@@ -12,10 +12,7 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
-import android.hardware.SensorManager.AXIS_MINUS_X
-import android.hardware.SensorManager.AXIS_MINUS_Y
-import android.hardware.SensorManager.AXIS_X
-import android.hardware.SensorManager.AXIS_Y
+import android.hardware.SensorManager.*
 import android.location.Location
 import android.os.Build
 import android.os.Looper
@@ -242,6 +239,9 @@ class ITMGeolocationManager(private var context: Context) {
         }
 
         override fun onSensorChanged(event: SensorEvent?) {
+            if (event?.accuracy == SENSOR_STATUS_UNRELIABLE || event?.accuracy == SENSOR_STATUS_ACCURACY_LOW) {
+                return
+            }
             when (event?.sensor?.type) {
                 Sensor.TYPE_ACCELEROMETER -> {
                     accelerometerReading = event.values.copyOf()


### PR DESCRIPTION
Note: this may prevent all compass readings, but not having a reading is better than having one that is totally wrong, which is what SYNCHRO Field testers are seeing.