### PR TITLE
Add custom error handling for the ITMGeolocationManager

### DIFF
--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
@@ -46,7 +46,7 @@ import kotlin.math.*
  *
  * @param context: The [Context] that is used for interacting with Android.
  */
-class ITMGeolocationManager(private var context: Context, private val customErrorHandler: ((Context, String) -> Unit)? = null) {
+class ITMGeolocationManager(private var context: Context, private val errorHandler: ErrorHandler? = null) {
     private val geolocationJsInterface = object {
         @JavascriptInterface
         fun getCurrentPosition(positionId: Int) {
@@ -183,7 +183,7 @@ class ITMGeolocationManager(private var context: Context, private val customErro
      */
     fun associateWithActivity(activity: ComponentActivity) {
         context = activity
-        requester = ITMGeolocationRequester(activity, customErrorHandler)
+        requester = ITMGeolocationRequester(activity, errorHandler)
         addLifecycleObserver(activity)
     }
 
@@ -193,7 +193,7 @@ class ITMGeolocationManager(private var context: Context, private val customErro
      * @param fragment The [Fragment] to associate with.
      */
     fun associateWithFragment(fragment: Fragment) {
-        requester = ITMGeolocationRequester(fragment, customErrorHandler)
+        requester = ITMGeolocationRequester(fragment, errorHandler)
         addLifecycleObserver(fragment)
     }
 

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
@@ -46,7 +46,7 @@ import kotlin.math.*
  *
  * @param context: The [Context] that is used for interacting with Android.
  */
-class ITMGeolocationManager(private var context: Context) {
+class ITMGeolocationManager(private var context: Context, private val customGeolocationPermissionErrorHandler: ((String) -> Unit)? = null) {
     private val geolocationJsInterface = object {
         @JavascriptInterface
         fun getCurrentPosition(positionId: Int) {
@@ -183,7 +183,7 @@ class ITMGeolocationManager(private var context: Context) {
      */
     fun associateWithActivity(activity: ComponentActivity) {
         context = activity
-        requester = ITMGeolocationRequester(activity)
+        requester = ITMGeolocationRequester(activity, customGeolocationPermissionErrorHandler)
         addLifecycleObserver(activity)
     }
 
@@ -193,7 +193,7 @@ class ITMGeolocationManager(private var context: Context) {
      * @param fragment The [Fragment] to associate with.
      */
     fun associateWithFragment(fragment: Fragment) {
-        requester = ITMGeolocationRequester(fragment)
+        requester = ITMGeolocationRequester(fragment, customGeolocationPermissionErrorHandler)
         addLifecycleObserver(fragment)
     }
 

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
@@ -46,7 +46,7 @@ import kotlin.math.*
  *
  * @param context: The [Context] that is used for interacting with Android.
  */
-class ITMGeolocationManager(private var context: Context, private val customErrorHandler: ((String) -> Unit)? = null) {
+class ITMGeolocationManager(private var context: Context, private val customErrorHandler: ((Context, String) -> Unit)? = null) {
     private val geolocationJsInterface = object {
         @JavascriptInterface
         fun getCurrentPosition(positionId: Int) {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
@@ -46,7 +46,7 @@ import kotlin.math.*
  *
  * @param context: The [Context] that is used for interacting with Android.
  */
-class ITMGeolocationManager(private var context: Context, private val customGeolocationPermissionErrorHandler: ((String) -> Unit)? = null) {
+class ITMGeolocationManager(private var context: Context, private val customErrorHandler: ((String) -> Unit)? = null) {
     private val geolocationJsInterface = object {
         @JavascriptInterface
         fun getCurrentPosition(positionId: Int) {
@@ -183,7 +183,7 @@ class ITMGeolocationManager(private var context: Context, private val customGeol
      */
     fun associateWithActivity(activity: ComponentActivity) {
         context = activity
-        requester = ITMGeolocationRequester(activity, customGeolocationPermissionErrorHandler)
+        requester = ITMGeolocationRequester(activity, customErrorHandler)
         addLifecycleObserver(activity)
     }
 
@@ -193,7 +193,7 @@ class ITMGeolocationManager(private var context: Context, private val customGeol
      * @param fragment The [Fragment] to associate with.
      */
     fun associateWithFragment(fragment: Fragment) {
-        requester = ITMGeolocationRequester(fragment, customGeolocationPermissionErrorHandler)
+        requester = ITMGeolocationRequester(fragment, customErrorHandler)
         addLifecycleObserver(fragment)
     }
 

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationRequester.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationRequester.kt
@@ -48,16 +48,16 @@ fun Context.checkFineLocationPermission() =
  */
 internal class ITMGeolocationRequester private constructor(resultCaller: ActivityResultCaller) {
     private lateinit var context: Context
-    private var customGeolocationPermissionErrorHandler: ((String) -> Unit)? = null
+    private var customErrorHandler: ((String) -> Unit)? = null
 
     private val requestPermission = resultCaller.registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
         requestPermissionsTask?.complete(isGranted)
         requestPermissionsTask = null
         if (!isGranted) {
-            if (customGeolocationPermissionErrorHandler == null) {
-                Toast.makeText(context, context.getString(R.string.itm_location_permissions_error_toast_text), Toast.LENGTH_LONG).show()
+            if (customErrorHandler != null) {
+                customErrorHandler?.invoke(context.getString(R.string.itm_location_permissions_error_toast_text))
             } else {
-                customGeolocationPermissionErrorHandler?.invoke(context.getString(R.string.itm_location_permissions_error_toast_text))
+                Toast.makeText(context, context.getString(R.string.itm_location_permissions_error_toast_text), Toast.LENGTH_LONG).show()
             }
         }
     }
@@ -78,9 +78,9 @@ internal class ITMGeolocationRequester private constructor(resultCaller: Activit
     /**
      * Constructor using a [ComponentActivity] as the [ActivityResultCaller] and [Context].
      */
-    constructor(activity: ComponentActivity, customGeolocationPermissionErrorHandler: ((String) -> Unit)? = null) : this(activity as ActivityResultCaller) {
+    constructor(activity: ComponentActivity, customErrorHandler: ((String) -> Unit)? = null) : this(activity as ActivityResultCaller) {
         this.context = activity
-        this.customGeolocationPermissionErrorHandler = customGeolocationPermissionErrorHandler
+        this.customErrorHandler = customErrorHandler
         activity.lifecycle.addObserver(object: DefaultLifecycleObserver {
             override fun onDestroy(owner: LifecycleOwner) {
                 unregister()
@@ -101,8 +101,8 @@ internal class ITMGeolocationRequester private constructor(resultCaller: Activit
      * Constructor using a [Fragment] as the as the [ActivityResultCaller], and the fragment's
      * activity or context will be used as the [Context].
      */
-    constructor(fragment: Fragment, customGeolocationPermissionErrorHandler: ((String) -> Unit)? = null) : this(fragment as ActivityResultCaller) {
-        this.customGeolocationPermissionErrorHandler = customGeolocationPermissionErrorHandler
+    constructor(fragment: Fragment, customErrorHandler: ((String) -> Unit)? = null) : this(fragment as ActivityResultCaller) {
+        this.customErrorHandler = customErrorHandler
         fragment.lifecycle.addObserver(object: DefaultLifecycleObserver {
             override fun onStart(owner: LifecycleOwner) {
                 context = fragment.activity ?: fragment.requireContext()

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationRequester.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationRequester.kt
@@ -48,14 +48,14 @@ fun Context.checkFineLocationPermission() =
  */
 internal class ITMGeolocationRequester private constructor(resultCaller: ActivityResultCaller) {
     private lateinit var context: Context
-    private var customErrorHandler: ((String) -> Unit)? = null
+    private var customErrorHandler: ((Context, String) -> Unit)? = null
 
     private val requestPermission = resultCaller.registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
         requestPermissionsTask?.complete(isGranted)
         requestPermissionsTask = null
         if (!isGranted) {
             if (customErrorHandler != null) {
-                customErrorHandler?.invoke(context.getString(R.string.itm_location_permissions_error_toast_text))
+                customErrorHandler?.invoke(context, context.getString(R.string.itm_location_permissions_error_toast_text))
             } else {
                 Toast.makeText(context, context.getString(R.string.itm_location_permissions_error_toast_text), Toast.LENGTH_LONG).show()
             }
@@ -78,7 +78,7 @@ internal class ITMGeolocationRequester private constructor(resultCaller: Activit
     /**
      * Constructor using a [ComponentActivity] as the [ActivityResultCaller] and [Context].
      */
-    constructor(activity: ComponentActivity, customErrorHandler: ((String) -> Unit)? = null) : this(activity as ActivityResultCaller) {
+    constructor(activity: ComponentActivity, customErrorHandler: ((Context, String) -> Unit)? = null) : this(activity as ActivityResultCaller) {
         this.context = activity
         this.customErrorHandler = customErrorHandler
         activity.lifecycle.addObserver(object: DefaultLifecycleObserver {
@@ -101,7 +101,7 @@ internal class ITMGeolocationRequester private constructor(resultCaller: Activit
      * Constructor using a [Fragment] as the as the [ActivityResultCaller], and the fragment's
      * activity or context will be used as the [Context].
      */
-    constructor(fragment: Fragment, customErrorHandler: ((String) -> Unit)? = null) : this(fragment as ActivityResultCaller) {
+    constructor(fragment: Fragment, customErrorHandler: ((Context, String) -> Unit)? = null) : this(fragment as ActivityResultCaller) {
         this.customErrorHandler = customErrorHandler
         fragment.lifecycle.addObserver(object: DefaultLifecycleObserver {
             override fun onStart(owner: LifecycleOwner) {

--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationRequester.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationRequester.kt
@@ -49,14 +49,14 @@ fun Context.checkFineLocationPermission() =
  * @param resultCaller The [ActivityResultCaller] to associate with.
  * @param errorHandler The error handler to use when displaying errors. Defaults to a Toast.
  */
-internal class ITMGeolocationRequester private constructor(resultCaller: ActivityResultCaller, private var errorHandler: ErrorHandler = ::defaultErrorHandler) {
+internal class ITMGeolocationRequester private constructor(resultCaller: ActivityResultCaller, private val errorHandler: ErrorHandler) {
     private lateinit var context: Context
 
     private val requestPermission = resultCaller.registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
         requestPermissionsTask?.complete(isGranted)
         requestPermissionsTask = null
         if (!isGranted) {
-            errorHandler.invoke(context, context.getString(R.string.itm_location_permissions_error_toast_text))
+            errorHandler(context, context.getString(R.string.itm_location_permissions_error_toast_text))
         }
     }
 
@@ -76,9 +76,8 @@ internal class ITMGeolocationRequester private constructor(resultCaller: Activit
     /**
      * Constructor using a [ComponentActivity] as the [ActivityResultCaller] and [Context].
      */
-    constructor(activity: ComponentActivity, errorHandler: ErrorHandler? = null) : this(activity as ActivityResultCaller) {
+    constructor(activity: ComponentActivity, errorHandler: ErrorHandler?) : this(activity as ActivityResultCaller, errorHandler ?: ::defaultErrorHandler) {
         this.context = activity
-        errorHandler?.let { this.errorHandler = it }
         activity.lifecycle.addObserver(object: DefaultLifecycleObserver {
             override fun onDestroy(owner: LifecycleOwner) {
                 unregister()
@@ -99,8 +98,7 @@ internal class ITMGeolocationRequester private constructor(resultCaller: Activit
      * Constructor using a [Fragment] as the as the [ActivityResultCaller], and the fragment's
      * activity or context will be used as the [Context].
      */
-    constructor(fragment: Fragment, errorHandler: ErrorHandler? = null) : this(fragment as ActivityResultCaller) {
-        errorHandler?.let { this.errorHandler = it }
+    constructor(fragment: Fragment, errorHandler: ErrorHandler?) : this(fragment as ActivityResultCaller, errorHandler ?: ::defaultErrorHandler) {
         fragment.lifecycle.addObserver(object: DefaultLifecycleObserver {
             override fun onStart(owner: LifecycleOwner) {
                 context = fragment.activity ?: fragment.requireContext()


### PR DESCRIPTION
**Problem:**
In our app, instead of getting `Toast` message `Please approve required permissions to show your location.`, we want to show alert, with the option to open the app settings:
![image](https://github.com/user-attachments/assets/133d4803-c7f6-47b7-a3b8-05a3bc152bb0)

**Solution**
Added `customErrorHandler` variable, which can be set externally.
If the variable is null, the `Toast` is used.