### PR TITLE
Fixed current location button not working on the first time the map is loaded

### DIFF
--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
@@ -395,7 +395,7 @@ class ITMGeolocationManager(private var context: Context, private val errorHandl
         ensureLocationAvailability()
         getWatchIds {
             it.add(positionId)
-            if (it.size == 0) {
+            if (it.size == 1) {
                 requestLocationUpdates()
             }
         }


### PR DESCRIPTION
When the map is loaded the first time, the current location button is not working, until the device is rotated:
![54c383bc-4a8a-4d0d-ad00-aa38b237ad0d-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/3dbbac65-620b-44a0-bfa6-771ce86d2106)

Looked into the code, noticed that in this PR https://github.com/iTwin/mobile-sdk-android/pull/97/files
in the `trackPosition` method 1 was changed to 0:
![image](https://github.com/user-attachments/assets/646264df-44f6-448e-adb8-4b16a1c72e43)

Not sure why it was done, maybe by mistake, but changing it back to 1 makes the current location work on the first time the Map is loaded in  android.