### PR TITLE
Fixed current location button not working on the first time the map is loaded (backport #98)

### DIFF
--- a/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
+++ b/mobile-sdk/src/main/java/com/github/itwin/mobilesdk/ITMGeolocationManager.kt
@@ -395,7 +395,7 @@ class ITMGeolocationManager(private var context: Context, private val errorHandl
         ensureLocationAvailability()
         getWatchIds {
             it.add(positionId)
-            if (it.size == 0) {
+            if (it.size == 1) {
                 requestLocationUpdates()
             }
         }


### PR DESCRIPTION
Backport of https://github.com/iTwin/mobile-sdk-android/pull/98